### PR TITLE
Plugins, unified routing, and control messages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,7 @@
 name: Build release artifacts
+permissions:
+    contents: read
+    packages: write
 
 on:
     workflow_call:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,60 @@
+name: Build release artifacts
+
+on:
+    workflow_call:
+        inputs:
+            tag:
+                description: 'The tag for this binary, i.e. "v1.2.3" or "git-<sha>"'
+                type: string
+                required: true
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/terrapkg/builder:f42
+        steps:
+            - name: Install dependencies
+              run: |
+                  dnf install -y clang-devel gcc mold cmake pkg-config libevdev-devel libudev-devel dbus-devel
+            - uses: actions/checkout@v5
+            - name: Set up Rust
+              uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                  profile: minimal
+                  override: true
+                  components: rustfmt, clippy
+
+            - name: Cache cargo registry
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                  key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+            - name: Cache cargo build
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      target/
+                  key: ${{ runner.os }}-cargo-build-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}
+            - name: Build release binaries
+              run: |
+                  cargo build --release
+
+            - name: Set up artifacts
+              run: |
+                  outdir=out/backflow-${{ inputs.tag }}-${{ runner.arch }}
+                  mkdir -p $outdir
+                  cp target/release/backflow $outdir/
+                  cp -a web/ $outdir/web
+                  tar czf backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz out/backflow-${{ inputs.tag }}-${{ runner.arch }}
+            - name: Upload artifact
+              id: upload-artifact
+              uses: actions/upload-artifact@v3
+              with:
+                  name: backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz
+                  path: backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz
+        outputs:
+            artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
                   mkdir -p $outdir
                   cp target/release/backflow $outdir/
                   cp -a web/ $outdir/web
-                  tar czf backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz out/backflow-${{ inputs.tag }}-${{ runner.arch }}
+                  tar czf backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz -C out backflow-${{ inputs.tag }}-${{ runner.arch }}
 
             - name: Upload artifact
               id: upload-artifact

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,24 +21,10 @@ jobs:
             - name: Set up Rust
               uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
-                  profile: minimal
                   override: true
-                  components: rustfmt, clippy
+                  cache: true
+                  rustflags: ""
 
-            - name: Cache cargo registry
-              uses: actions/cache@v4
-              with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                  key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-            - name: Cache cargo build
-              uses: actions/cache@v4
-              with:
-                  path: |
-                      target/
-                  key: ${{ runner.os }}-cargo-build-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}
             - name: Build release binaries
               run: |
                   cargo build --release
@@ -50,6 +36,7 @@ jobs:
                   cp target/release/backflow $outdir/
                   cp -a web/ $outdir/web
                   tar czf backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz out/backflow-${{ inputs.tag }}-${{ runner.arch }}
+
             - name: Upload artifact
               id: upload-artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
                   tar czf backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz out/backflow-${{ inputs.tag }}-${{ runner.arch }}
             - name: Upload artifact
               id: upload-artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz
                   path: backflow-${{ inputs.tag }}-${{ runner.arch }}.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,3 +16,5 @@ jobs:
 
     build:
         uses: ./.github/workflows/build.yaml
+        with:
+            tag: git-${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
             test-pre: dnf install -y clang-devel gcc mold cmake pkg-config libevdev-devel libudev-devel dbus-devel
 
     build:
+        permissions:
+            contents: read
+            packages: write
         uses: ./.github/workflows/build.yaml
         with:
             tag: git-${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,18 @@
 name: Rust
 
 permissions:
-  security-events: write
+    security-events: write
 
 on:
-  push:
-  pull_request:
+    push:
+    pull_request:
 
 jobs:
-  rust:
-    uses: FyraLabs/actions/.github/workflows/rust.yml@main
-    with:
-      test-container: '{"image": "ghcr.io/terrapkg/builder:f42"}'
-      test-pre: dnf install -y clang-devel gcc mold cmake pkg-config libevdev-devel libudev-devel dbus-devel
+    rust:
+        uses: FyraLabs/actions/.github/workflows/rust.yml@main
+        with:
+            test-container: '{"image": "ghcr.io/terrapkg/builder:f42"}'
+            test-pre: dnf install -y clang-devel gcc mold cmake pkg-config libevdev-devel libudev-devel dbus-devel
+
+    build:
+        uses: ./.github/workflows/build.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,4 +26,4 @@ jobs:
               uses: softprops/action-gh-release@v2
               if: github.ref_type == 'tag'
               with:
-                  files: *.tar.gz
+                  files: "*.tar.gz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release binaries
+
+permissions:
+    contents: write
+    packages: write
+    id-token: write
+
+on:
+    release:
+        types:
+            - released
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/terrapkg/builder:f42
+        steps:
+            - name: Build binaries
+              id: build
+              uses: ./.github/workflows/build.yaml
+              with:
+                  tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,3 +21,9 @@ jobs:
               uses: ./.github/workflows/build.yaml
               with:
                   tag: ${{ github.event.release.tag_name }}
+
+            - name: Release
+              uses: softprops/action-gh-release@v2
+              if: github.ref_type == 'tag'
+              with:
+                  files: *.tar.gz

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > Remap and route input from any device — adaptive controllers, arcade boards, or DIY hardware — with no kernel drivers, no lock-in.
 
-**Backflow** is a daemon that bridges unconventional input devices to standard HID events, powered by [InputPlumber](https://github.com/ShadowBlip/InputPlumber). Whether you're using analog controls, serial interfaces, web-based gamepads, MIDI devices, or other custom hardware, Backflow provides a modular way to route and remap any input into standard keyboard, mouse, or gamepad events.
+**Backflow** is an input router and message broker that bridges unconventional input devices to standard HID events, powered by [InputPlumber](https://github.com/ShadowBlip/InputPlumber). Whether you're using analog controls, serial interfaces, web-based gamepads, MIDI devices, or other custom hardware, Backflow provides a modular way to route and remap any input into standard keyboard, mouse, or gamepad events.
 
 Whether you're building a virtual gamepad in a browser, integrating RS232 or MIDI devices, or enabling hands-free control through custom hardware, Backflow helps unify everything into one virtual input stack.
 

--- a/crates/zbus-inputplumber/Cargo.toml
+++ b/crates/zbus-inputplumber/Cargo.toml
@@ -9,4 +9,4 @@ zbus = "5"
 zvariant = "5"
 serde = { version = "1.0", features = ["derive"] }
 async-dropper = { version = "0.3", features = ["tokio", "derive"] }
-async-trait = "0.1.88"
+async-trait = "~0.1"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -228,7 +228,7 @@ impl Backend {
         let device_filter = DeviceFilter::new(&config);
         let event_router = EventRouter::new();
 
-        let io_server = Arc::new(IoEventServer::new());
+        let io_server = Arc::new(IoEventServer::with_config(Arc::new(config.clone())));
         // Spawn unified IO server processing loop now (bridged below)
         let io_server_clone = io_server.clone();
         tokio::spawn(async move {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,15 +4,15 @@
 
 use crate::config::AppConfig;
 use crate::device_filter::DeviceFilter;
-use crate::feedback::FeedbackEventStream;
 use crate::feedback::generators::chuni_jvs::ChuniLedDataPacket;
-use crate::input::{InputBackend, InputEventStream};
+use crate::input::io_server::{IoEventServer, IoOutboundMessage};
+use crate::input::{InputBackend, InputEventPacket, InputEventStream};
 use crate::output::{OutputBackend, OutputBackendType};
 use eyre::Result;
 use futures::future::select_all;
-use rustc_hash::FxHashMap;
 use std::future::Future;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
@@ -167,52 +167,40 @@ impl Default for EventRouter {
         Self::new()
     }
 }
-/// Message streams container for passing around shared streams
+/// Message streams container maintaining per-output backend input streams
 #[derive(Clone)]
 pub struct MessageStreams {
-    /// Raw input events from all input backends
-    pub raw_input: InputEventStream,
-    /// Feedback events for all backends
-    pub feedback: FeedbackEventStream,
     /// Output streams keyed by backend name
-    output_streams: FxHashMap<String, InputEventStream>,
+    output_streams: std::collections::HashMap<String, InputEventStream>,
 }
 
 impl MessageStreams {
-    /// Create a new MessageStreams with default output backends
     pub fn new() -> Self {
-        let mut output_streams = FxHashMap::default();
-
-        // Register default output stream backends
+        let mut output_streams = std::collections::HashMap::new();
+        // Default backends
         output_streams.insert("uinput".to_string(), InputEventStream::new());
         output_streams.insert("chuniio".to_string(), InputEventStream::new());
-
-        Self {
-            raw_input: InputEventStream::new(),
-            feedback: FeedbackEventStream::new(),
-            output_streams,
-        }
+        Self { output_streams }
     }
-
-    /// Register a new output stream for a backend
+    /// Ensure a stream exists for the given backend name; returns true if newly created.
+    pub fn ensure_stream(&mut self, backend_name: &str) -> bool {
+        if self.output_streams.contains_key(backend_name) {
+            return false;
+        }
+        self.output_streams
+            .insert(backend_name.to_string(), InputEventStream::new());
+        true
+    }
     pub fn register_output_stream(&mut self, backend_name: &str) -> InputEventStream {
         let stream = InputEventStream::new();
         self.output_streams
             .insert(backend_name.to_string(), stream.clone());
         stream
     }
-
-    /// Get an output stream by backend name
-    pub fn get_output_stream(&self, backend_name: &str) -> Option<&InputEventStream> {
-        self.output_streams.get(backend_name)
-    }
-
-    /// Get a cloned output stream by backend name (for moving into async tasks)
     pub fn clone_output_stream(&self, backend_name: &str) -> Option<InputEventStream> {
         self.output_streams.get(backend_name).cloned()
     }
-
-    /// Get all registered output backend names
+    #[allow(dead_code)]
     pub fn output_backend_names(&self) -> impl Iterator<Item = &String> {
         self.output_streams.keys()
     }
@@ -227,25 +215,44 @@ impl Default for MessageStreams {
 /// Represents the actual backend service
 pub struct Backend {
     config: AppConfig,
-    streams: MessageStreams,
     device_filter: DeviceFilter,
     event_router: EventRouter,
     service_manager: ServiceManager,
+    io_server: Arc<IoEventServer>,
+    streams: MessageStreams,
 }
 
 impl Backend {
     /// Create a new backend from configuration
     pub fn new(config: AppConfig) -> Self {
         let device_filter = DeviceFilter::new(&config);
-        let streams = MessageStreams::new();
         let event_router = EventRouter::new();
 
+        let io_server = Arc::new(IoEventServer::new());
+        // Spawn unified IO server processing loop now (bridged below)
+        let io_server_clone = io_server.clone();
+        tokio::spawn(async move {
+            if let Err(e) = io_server_clone.run_forever().await {
+                tracing::error!("IoEventServer error: {}", e);
+            }
+        });
+        // Initialize message streams (defaults for built-in backends)
+        let mut streams = MessageStreams::new();
+        // Auto-register any additional backend names referenced in device config
+        // so routing can emit to them without needing an output service yet.
+        // This makes adding future output backends config-first.
+        for (_dev_id, dev_cfg) in &config.device {
+            let backend_name = dev_cfg.map_backend.as_str();
+            // Ensure a stream exists for each referenced backend.
+            streams.ensure_stream(backend_name);
+        }
         Self {
             config,
-            streams,
             device_filter,
             event_router,
             service_manager: ServiceManager::new(),
+            io_server,
+            streams,
         }
     }
 
@@ -274,12 +281,10 @@ impl Backend {
 
         let (led_packet_tx, led_packet_rx) =
             crate::feedback::generators::chuni_jvs::create_chuni_led_channel();
-
-        // Start all services, managed by the ServiceManager
         self.start_input_services();
-        self.start_device_filter_service();
         self.start_output_services(led_packet_tx);
         self.start_feedback_services(led_packet_rx);
+        self.start_routing_service();
 
         tracing::info!("All backend services started successfully");
         Ok(())
@@ -337,15 +342,12 @@ impl Backend {
         let bind_addr_str = format!("{host}:{port}");
         tracing::info!("Starting web input backend on {bind_addr_str}");
 
-        let input_stream = self.streams.raw_input.clone();
-        let feedback_stream = self.streams.feedback.clone();
-
+        let io_server = self.io_server.clone();
         self.spawn_service("web_input", async move {
             match bind_addr_str.parse::<SocketAddr>() {
                 Ok(bind_addr) => {
                     use crate::input::web::WebServer;
-                    let mut ws_backend =
-                        WebServer::auto_detect_web_ui(bind_addr, input_stream, feedback_stream);
+                    let mut ws_backend = WebServer::auto_detect_web_ui(bind_addr, io_server);
                     if let Err(e) = ws_backend.run().await {
                         tracing::error!("WebSocket backend error: {}", e);
                     }
@@ -360,13 +362,10 @@ impl Backend {
     /// Start Unix socket input service with parameters
     fn start_unix_socket_service_with_params(&mut self, path: std::path::PathBuf) {
         tracing::info!("Starting unix socket input backend at {}", path.display());
-
-        let input_stream = self.streams.raw_input.clone();
-        let feedback_stream = self.streams.feedback.clone();
-
+        let io_server = self.io_server.clone();
         self.spawn_service("unix_socket", async move {
             use crate::input::unix_socket::UnixSocketServer;
-            let mut unix_backend = UnixSocketServer::new(path, input_stream, feedback_stream);
+            let mut unix_backend = UnixSocketServer::new(path, io_server);
             if let Err(e) = unix_backend.run().await {
                 tracing::error!("Unix socket backend error: {}", e);
             }
@@ -395,19 +394,13 @@ impl Backend {
     fn start_brokenithm_tcp_service_with_params(&mut self, host: String, port: u16) {
         let connect_addr_str = format!("{host}:{port}");
         tracing::info!("Starting Brokenithm TCP client backend to {connect_addr_str}");
-
-        let input_stream = self.streams.raw_input.clone();
-        let feedback_stream = self.streams.feedback.clone();
-
+        let io_server = self.io_server.clone();
         self.spawn_service("brokenithm_tcp", async move {
             match connect_addr_str.parse::<SocketAddr>() {
                 Ok(connect_addr) => {
-                    use crate::input::brokenithm::{BrokenithmTcpBackend, BrokenithmTcpConfig};
-                    let mut backend = BrokenithmTcpBackend::new(
-                        BrokenithmTcpConfig::Client { connect_addr },
-                        input_stream,
-                        feedback_stream,
-                    );
+                    use crate::input::brokenithm::BrokenithmTcpBackend;
+                    let inbound_tx = io_server.inbound_sender();
+                    let mut backend = BrokenithmTcpBackend::client(connect_addr, inbound_tx);
                     if let Err(e) = backend.run().await {
                         tracing::error!("Brokenithm TCP client backend error: {}", e);
                     }
@@ -433,20 +426,12 @@ impl Backend {
             udid
         );
 
-        let input_stream = self.streams.raw_input.clone();
-        let feedback_stream = self.streams.feedback.clone();
-
+        let io_server = self.io_server.clone();
         self.spawn_service("brokenithm_idevice", async move {
-            use crate::input::brokenithm::{BrokenithmTcpBackend, BrokenithmTcpConfig};
-            let mut backend = BrokenithmTcpBackend::new(
-                BrokenithmTcpConfig::DeviceProxy {
-                    local_port,
-                    device_port,
-                    udid,
-                },
-                input_stream,
-                feedback_stream,
-            );
+            use crate::input::brokenithm::BrokenithmTcpBackend;
+            let inbound_tx = io_server.inbound_sender();
+            let mut backend =
+                BrokenithmTcpBackend::device_proxy(local_port, device_port, udid, inbound_tx);
             if let Err(e) = backend.run().await {
                 tracing::error!("Brokenithm iDevice client backend error: {}", e);
             }
@@ -454,76 +439,50 @@ impl Backend {
     }
 
     /// Start device filter and routing service that transforms raw input events and routes them to appropriate backends
-    fn start_device_filter_service(&mut self) {
-        tracing::info!("Starting device filter and routing service");
-
-        let raw_input_stream = self.streams.raw_input.clone();
-        let streams_for_routing = self.streams.clone();
+    fn start_routing_service(&mut self) {
+        tracing::info!("Starting unified routing service (IoEventServer -> output backends)");
+        let io_server = self.io_server.clone();
         let device_filter = self.device_filter.clone();
         let event_router = self.event_router.clone();
-
-        self.service_manager.spawn(async move {
-            loop {
-                // Receive from raw input stream
-                if let Some(packet) = raw_input_stream.receive().await {
-                    match device_filter.transform_packet(packet) {
-                        Ok(transformed_packet) => {
-                            // Group events by destination backend
-                            let mut backend_events: FxHashMap<String, Vec<crate::input::InputEvent>> = FxHashMap::default();
-
-                            for event in &transformed_packet.events {
-                                if let Some(backend_name) = event_router.route_event(event, Some(&device_filter), &transformed_packet.device_id) {
-                                    backend_events.entry(backend_name)
-                                        .or_default()
-                                        .push(event.clone());
-                                }
-                            }
-
-                            // Send events to their respective backends
-                            for (backend_name, events) in backend_events {
-                                if let Some(output_stream) = streams_for_routing.clone_output_stream(&backend_name) {
-                                    let packet = crate::input::InputEventPacket {
-                                        device_id: transformed_packet.device_id.clone(),
-                                        timestamp: transformed_packet.timestamp,
-                                        events,
-                                    };
-
-                                    tracing::trace!(
-                                        "Routing {} events from device '{}' to {} backend",
-                                        packet.events.len(),
-                                        packet.device_id,
-                                        backend_name
-                                    );
-                                    let span = tracing::span!(
-                                        tracing::Level::TRACE,
-                                        "send_packet_to_backend",
-                                        backend = %backend_name,
-                                        device_id = %packet.device_id,
-                                        event_count = packet.events.len()
-                                    );
-                                    let _enter = span.enter();
-                                    if let Err(e) = output_stream.send(packet).await {
-                                        tracing::error!(
-                                            "Failed to send packet to {} backend: {}",
-                                            backend_name, e
-                                        );
+        let streams = self.streams.clone();
+        self.spawn_service("routing_service", async move {
+            if let Some(mut outbound_rx) = io_server.take_outbound_receiver().await {
+                while let Some(msg) = outbound_rx.recv().await {
+                    match msg {
+                        IoOutboundMessage::Input(pkt) => {
+                            match device_filter.transform_packet(pkt) {
+                                Ok(transformed_packet) => {
+                                    // Group by backend
+                                    let mut by_backend: std::collections::HashMap<String, Vec<crate::input::InputEvent>> = std::collections::HashMap::new();
+                                    for ev in &transformed_packet.events {
+                                        if let Some(backend_name) = event_router.route_event(ev, Some(&device_filter), &transformed_packet.device_id) {
+                                            by_backend.entry(backend_name).or_default().push(ev.clone());
+                                        }
                                     }
-                                } else {
-                                    tracing::warn!(
-                                        "No output stream registered for backend '{}', dropping {} events",
-                                        backend_name, events.len()
-                                    );
+                                    for (backend, events) in by_backend {
+                                        if events.is_empty() { continue; }
+                                        if let Some(stream) = streams.clone_output_stream(&backend) {
+                                            let packet = InputEventPacket { device_id: transformed_packet.device_id.clone(), timestamp: transformed_packet.timestamp, events };
+                                            if let Err(e) = stream.send(packet.clone()).await { tracing::error!("Failed to send packet to backend {backend}: {e}"); }
+                                            // Mirror to client subscribers of this backend/topic
+                                            io_server.broadcast_stream_input(&backend, &packet);
+                                            // Also mirror to device listeners (clients that did not register streams)
+                                            io_server.broadcast_device_input(&packet);
+                                        } else {
+                                            tracing::warn!("No stream registered for backend {backend}, dropping events");
+                                        }
+                                    }
                                 }
+                                Err(e) => tracing::error!("Failed to transform packet: {e}"),
                             }
                         }
-                        Err(e) => {
-                            tracing::error!("Failed to transform packet: {}", e);
+                        IoOutboundMessage::Feedback(_fb) => {
+                            // Already dispatched to clients; no output backend consumes feedback currently
                         }
                     }
-                } else {
-                    tracing::debug!("Raw input stream closed, shutting down device filter");
-                    break;
                 }
+            } else {
+                tracing::warn!("Failed to obtain IoEventServer outbound receiver; routing inactive");
             }
         });
     }
@@ -554,8 +513,7 @@ impl Backend {
         let input_stream = self
             .streams
             .clone_output_stream("uinput")
-            .expect("uinput output stream should be registered");
-
+            .expect("uinput stream registered");
         self.spawn_service("uinput_output", async move {
             let output_result = crate::output::udev::UdevOutput::new(input_stream);
             match output_result {
@@ -592,15 +550,13 @@ impl Backend {
         let input_stream = self
             .streams
             .clone_output_stream("chuniio")
-            .expect("chuniio output stream should be registered");
-        let feedback_stream = self.streams.feedback.clone();
+            .expect("chuniio stream registered");
 
         self.spawn_service("chuniio_proxy", async move {
             let mut output = OutputBackendType::ChuniioProxy(
                 crate::output::chuniio_proxy::ChuniioProxyServer::new(
                     socket_path,
                     input_stream,
-                    feedback_stream,
                     led_packet_tx,
                 ),
             );
@@ -651,7 +607,7 @@ impl Backend {
         );
 
         let config = chuniio_config.clone();
-        let feedback_stream = self.streams.feedback.clone();
+        let io_server = self.io_server.clone();
         let socket_path = socket_path.clone();
 
         // Create a new channel for the JVS reader to send packets
@@ -670,7 +626,7 @@ impl Backend {
         // Start RGB service fed by JVS reader
         self.spawn_service("chuniio_rgb_service", async move {
             use crate::feedback::generators::chuni_jvs::run_chuniio_service;
-            if let Err(e) = run_chuniio_service(config, feedback_stream, jvs_led_rx).await {
+            if let Err(e) = run_chuniio_service(config, io_server, jvs_led_rx).await {
                 tracing::error!("ChuniIO RGB feedback service error: {}", e);
             }
         });
@@ -688,11 +644,11 @@ impl Backend {
         tracing::info!("Starting ChuniIO RGB feedback service (fed by chuniio_proxy, no socket)");
 
         let config = chuniio_config.clone();
-        let feedback_stream = self.streams.feedback.clone();
+        let io_server = self.io_server.clone();
 
         self.spawn_service("chuniio_rgb_service", async move {
             use crate::feedback::generators::chuni_jvs::run_chuniio_service;
-            if let Err(e) = run_chuniio_service(config, feedback_stream, led_packet_rx).await {
+            if let Err(e) = run_chuniio_service(config, io_server, led_packet_rx).await {
                 tracing::error!("ChuniIO RGB feedback service error: {}", e);
             }
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,31 @@ pub struct AppConfig {
     /// Per-device configurations for filtering and remapping
     #[serde(default)]
     pub device: HashMap<String, DeviceConfig>,
+    #[serde(default)]
+    pub plugins: Vec<PluginConfig>,
+}
+
+/// "Plugins" for Backflow
+///
+/// Backflow supports plugins that act as dedicated backend/frontends for devices the main tree.
+///
+/// These plugins are essentially just executables that communicate through Backflow through
+/// standard I/O interfaces.
+///
+/// Once configured, Backflow will simply manage this process, and read/write Input/Feedback events from the
+/// program.
+///
+/// The protocol is exactly the same as the UDS (Unix Domain Socket) or WebSockets implementation, AKA standard Backflow
+/// event messages
+///
+/// This is similar to how chess engines have the UCI (Universal Chess Interface) for communication.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PluginConfig {
+    /// Path to the plugin executable
+    pub command: String,
+    /// Optional CLI arguments to pass to the plugin, if need be.
+    #[serde(default)]
+    pub args: Vec<String>,
 }
 
 impl AppConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,9 @@ use crate::device_filter::KeyExpr;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use toml::Value;
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct AppConfig {
     #[serde(default)]
     pub input: InputConfig,
@@ -55,6 +56,10 @@ pub struct AppConfig {
     /// - Graceful shutdown signals
     #[serde(default)]
     pub plugins: Vec<PluginConfig>,
+
+    /// Global Plugin config, not used by Backflow itself
+    #[serde(default)]
+    pub plugin_settings: HashMap<String, Value>,
 }
 
 /// Configuration for a single plugin process.
@@ -186,7 +191,7 @@ impl AppConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct InputConfig {
     #[serde(default = "default_web_enabled")]
     pub web: Option<WebBackend>,
@@ -212,7 +217,7 @@ fn default_web_enabled() -> Option<WebBackend> {
     Some(WebBackend::default())
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct OutputConfig {
     #[serde(default)]
     pub uinput: UInputConfig,
@@ -220,7 +225,7 @@ pub struct OutputConfig {
     pub chuniio_proxy: Option<ChuniioProxyConfig>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct UnixDomainSocketConfig {
     #[serde(default = "default_unix_socket_path")]
     pub path: PathBuf,
@@ -241,7 +246,7 @@ fn default_unix_socket_path() -> PathBuf {
 }
 
 // set web.enabled = false in [input.web] to explicitly disable the web backend
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct WebBackend {
     #[serde(default = "default_web_enabled_bool")]
     pub enabled: bool,
@@ -273,7 +278,7 @@ fn default_web_host() -> String {
     "0.0.0.0".to_string()
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct UInputConfig {
     pub enabled: bool,
 }
@@ -284,7 +289,7 @@ impl Default for UInputConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct FeedbackConfig {
     // CHUNIIO RGB feedback socket
     pub chuniio: Option<ChuniIoRgbConfig>,
@@ -417,7 +422,7 @@ impl Default for DeviceConfig {
         }
     }
 }
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ChuniioProxyConfig {
     #[serde(default = "default_chuniio_proxy_enabled")]
     pub enabled: bool,
@@ -455,7 +460,7 @@ fn default_chuniio_proxy_socket_path() -> PathBuf {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct BrokenithmUdpConfig {
     #[serde(default = "default_brokenithm_enabled")]
     pub enabled: bool,
@@ -475,7 +480,7 @@ fn default_brokenithm_host() -> String {
     "0.0.0.0".to_string()
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct BrokenithmIdeviceConfig {
     #[serde(default = "default_brokenithm_enabled")]
     pub enabled: bool,
@@ -487,7 +492,7 @@ pub struct BrokenithmIdeviceConfig {
     pub udid: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct BrokenithmConfig {
     #[serde(default = "default_brokenithm_enabled")]
     pub enabled: bool,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,144 @@
+//! Unified application error types and conversion helpers.
+//! These errors are intended for internal use; transport-facing serialization
+//! happens via `IoErrorPacket` in `io_server` using `Into<ClientFacingError>`.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// High-level classification for mapping to client error codes.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorKind {
+    /// Malformed JSON / invalid schema
+    Parse,
+    /// Command was understood but arguments were invalid or out of range
+    Validation,
+    /// Referenced resource (device, stream, etc.) not found
+    NotFound,
+    /// Operation not permitted in current state or due to security policy
+    Permission,
+    /// Internal I/O failure (disk, socket, pipe)
+    Io,
+    /// Unexpected internal error / bug
+    Internal,
+}
+
+impl std::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|_| "internal".into())
+        )
+    }
+}
+
+/// Core error enum used throughout the application.
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("parse error: {0}")]
+    Parse(String),
+    // #[error("validation error: {0}")]
+    // Validation(String),
+    #[error("not found: {0}")]
+    // NotFound(String),
+    // #[error("permission denied: {0}")]
+    // Permission(String),
+    // #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl AppError {
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            AppError::Parse(_) => ErrorKind::Parse,
+            // AppError::Validation(_) => ErrorKind::Validation,
+            // AppError::NotFound(_) => ErrorKind::NotFound,
+            // AppError::Permission(_) => ErrorKind::Permission,
+            AppError::Io(_) => ErrorKind::Io,
+            AppError::Internal(_) => ErrorKind::Internal,
+        }
+    }
+
+    /// Short machine error code string (snake_case) used in client packets.
+    pub fn code(&self) -> &'static str {
+        match self.kind() {
+            ErrorKind::Parse => "parse_error",
+            ErrorKind::Validation => "validation_error",
+            ErrorKind::NotFound => "not_found",
+            ErrorKind::Permission => "permission_denied",
+            ErrorKind::Io => "io_error",
+            ErrorKind::Internal => "internal_error",
+        }
+    }
+}
+
+/// Simplified client-facing error payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientFacingError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<String>,
+}
+
+impl From<AppError> for ClientFacingError {
+    fn from(err: AppError) -> Self {
+        Self {
+            code: err.code().to_string(),
+            message: err.to_string(),
+            raw: None,
+        }
+    }
+}
+
+impl ClientFacingError {
+    pub fn with_raw(mut self, raw: impl Into<String>) -> Self {
+        self.raw = Some(raw.into());
+        self
+    }
+}
+
+/// Shorthand constructors for common errors.
+pub mod err {
+    use super::AppError;
+    pub fn parse(msg: impl Into<String>) -> AppError {
+        AppError::Parse(msg.into())
+    }
+    // pub fn validation(msg: impl Into<String>) -> AppError {
+    //     AppError::Validation(msg.into())
+    // }
+    // pub fn not_found(msg: impl Into<String>) -> AppError {
+    //     AppError::NotFound(msg.into())
+    // }
+    // pub fn permission(msg: impl Into<String>) -> AppError {
+    //     AppError::Permission(msg.into())
+    // }
+    pub fn internal(msg: impl Into<String>) -> AppError {
+        AppError::Internal(msg.into())
+    }
+}
+
+/// Simple JSON error response for REST endpoints (distinct from WS IoErrorPacket)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,   // machine code
+    pub message: String, // human readable
+}
+
+impl From<AppError> for ErrorResponse {
+    fn from(e: AppError) -> Self {
+        Self {
+            error: e.code().to_string(),
+            message: e.to_string(),
+        }
+    }
+}
+
+/// Macro for early-returning an AppError in functions returning Result<T, AppError>
+#[macro_export]
+macro_rules! bail_app {
+    ($variant:ident, $($arg:tt)*) => { return Err($crate::error::AppError::$variant(format!($($arg)*))) };
+}

--- a/src/feedback/generators/chuni_jvs.rs
+++ b/src/feedback/generators/chuni_jvs.rs
@@ -33,8 +33,8 @@
 //! Keep note that the slider LED indexes are in reverse order, so the first LED is on the right side of the slider,
 
 use crate::config::ChuniIoRgbConfig;
-use crate::input::io_server::{IoEventServer, IoInboundMessage};
 use crate::feedback::{FeedbackEvent, FeedbackEventPacket, LedEvent};
+use crate::input::io_server::{IoEventServer, IoInboundMessage};
 use std::path::PathBuf;
 use tokio::io::AsyncReadExt;
 use tokio::net::UnixListener;
@@ -485,7 +485,17 @@ pub struct ChuniRgbService {
 
 impl ChuniRgbService {
     /// Create a new CHUNITHM RGB feedback service
-    pub fn new(config: ChuniIoRgbConfig, io_server: std::sync::Arc<IoEventServer>, packet_receiver: mpsc::UnboundedReceiver<ChuniLedDataPacket>) -> Self { Self { config, io_server, packet_receiver } }
+    pub fn new(
+        config: ChuniIoRgbConfig,
+        io_server: std::sync::Arc<IoEventServer>,
+        packet_receiver: mpsc::UnboundedReceiver<ChuniLedDataPacket>,
+    ) -> Self {
+        Self {
+            config,
+            io_server,
+            packet_receiver,
+        }
+    }
 
     /// Start the RGB feedback service
     pub async fn run(&mut self) -> eyre::Result<()> {
@@ -546,7 +556,13 @@ impl ChuniRgbService {
 
             // Send feedback packet - use try_send for non-blocking transmission
             // Forward into unified IoEventServer
-            let _ = self.io_server.inbound_sender().send(IoInboundMessage::Feedback { client_id: "chuni_rgb_service".into(), packet: feedback_packet });
+            let _ = self
+                .io_server
+                .inbound_sender()
+                .send(IoInboundMessage::Feedback {
+                    client_id: "chuni_rgb_service".into(),
+                    packet: feedback_packet,
+                });
         }
 
         Ok(())

--- a/src/input/brokenithm/mod.rs
+++ b/src/input/brokenithm/mod.rs
@@ -4,14 +4,13 @@
 //!
 //! This module provides a TCP server/client that connects to Brokenithm clients,
 //! allowing them to send input events and receive updates.
-//! 
+//!
 //! NOTE: This module will be deprecated and turned into a separate plugin.
-//! 
+//!
 //! If you want to use a Brokenithm-like frontend on an iOS client, consider
 //! using the Web version, or the new plugin once complete
-//! 
+//!
 //! This backend will be removed once the dedicated plugin is complete.
-
 
 use crate::feedback::{FeedbackEvent, FeedbackEventPacket, LedEvent};
 use crate::input::io_server::IoInboundMessage;

--- a/src/input/brokenithm/mod.rs
+++ b/src/input/brokenithm/mod.rs
@@ -4,9 +4,18 @@
 //!
 //! This module provides a TCP server/client that connects to Brokenithm clients,
 //! allowing them to send input events and receive updates.
+//! 
+//! NOTE: This module will be deprecated and turned into a separate plugin.
+//! 
+//! If you want to use a Brokenithm-like frontend on an iOS client, consider
+//! using the Web version, or the new plugin once complete
+//! 
+//! This backend will be removed once the dedicated plugin is complete.
 
-use crate::feedback::{FeedbackEvent, FeedbackEventPacket, FeedbackEventStream, LedEvent};
-use crate::input::{InputBackend, InputEvent, InputEventPacket, InputEventStream, KeyboardEvent};
+
+use crate::feedback::{FeedbackEvent, FeedbackEventPacket, LedEvent};
+use crate::input::io_server::IoInboundMessage;
+use crate::input::{InputBackend, InputEvent, InputEventPacket, KeyboardEvent};
 use crate::output::rgb_to_brg;
 use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
@@ -90,8 +99,8 @@ pub async fn set_brokenithm_state(new_state: BoardInputState) {
 
 pub struct BrokenithmTcpBackend {
     pub config: BrokenithmTcpConfig,
-    pub input_stream: InputEventStream,
-    pub feedback_stream: FeedbackEventStream,
+    /// Inbound sender into unified IoEventServer (produces IoInboundMessage::Input)
+    pub inbound_tx: tokio::sync::mpsc::UnboundedSender<IoInboundMessage>,
 }
 
 #[derive(Debug, Clone)]
@@ -111,46 +120,30 @@ pub enum BrokenithmTcpConfig {
 impl BrokenithmTcpBackend {
     pub fn new(
         config: BrokenithmTcpConfig,
-        input_stream: InputEventStream,
-        feedback_stream: FeedbackEventStream,
+        inbound_tx: tokio::sync::mpsc::UnboundedSender<IoInboundMessage>,
     ) -> Self {
-        Self {
-            config,
-            input_stream,
-            feedback_stream,
-        }
+        Self { config, inbound_tx }
     }
 
     pub fn server(
         bind_addr: SocketAddr,
-        input_stream: InputEventStream,
-        feedback_stream: FeedbackEventStream,
+        inbound_tx: tokio::sync::mpsc::UnboundedSender<IoInboundMessage>,
     ) -> Self {
-        Self::new(
-            BrokenithmTcpConfig::Server { bind_addr },
-            input_stream,
-            feedback_stream,
-        )
+        Self::new(BrokenithmTcpConfig::Server { bind_addr }, inbound_tx)
     }
 
     pub fn client(
         connect_addr: SocketAddr,
-        input_stream: InputEventStream,
-        feedback_stream: FeedbackEventStream,
+        inbound_tx: tokio::sync::mpsc::UnboundedSender<IoInboundMessage>,
     ) -> Self {
-        Self::new(
-            BrokenithmTcpConfig::Client { connect_addr },
-            input_stream,
-            feedback_stream,
-        )
+        Self::new(BrokenithmTcpConfig::Client { connect_addr }, inbound_tx)
     }
 
     pub fn device_proxy(
         local_port: u16,
         device_port: u16,
         udid: Option<String>,
-        input_stream: InputEventStream,
-        feedback_stream: FeedbackEventStream,
+        inbound_tx: tokio::sync::mpsc::UnboundedSender<IoInboundMessage>,
     ) -> Self {
         Self::new(
             BrokenithmTcpConfig::DeviceProxy {
@@ -158,8 +151,7 @@ impl BrokenithmTcpBackend {
                 device_port,
                 udid,
             },
-            input_stream,
-            feedback_stream,
+            inbound_tx,
         )
     }
 }
@@ -211,10 +203,7 @@ impl InputBackend for BrokenithmTcpBackend {
 
         match self.config.clone() {
             BrokenithmTcpConfig::Server { bind_addr } => self.run_server(bind_addr).await,
-            BrokenithmTcpConfig::Client { connect_addr } => {
-                self.run_client(connect_addr, self.feedback_stream.clone())
-                    .await
-            }
+            BrokenithmTcpConfig::Client { connect_addr } => self.run_client(connect_addr).await,
             BrokenithmTcpConfig::DeviceProxy {
                 local_port,
                 device_port,
@@ -232,42 +221,9 @@ impl BrokenithmTcpBackend {
         let listener = TcpListener::bind(bind_addr).await?;
         tracing::info!("Brokenithm TCP backend listening on {}", bind_addr);
 
-        // Shared client list for feedback broadcast
+        // Legacy feedback broadcast removed
         let clients: Arc<RwLock<Vec<Arc<tokio::sync::Mutex<tokio::net::TcpStream>>>>> =
             Arc::new(RwLock::new(Vec::new()));
-        let feedback_stream = self.feedback_stream.clone();
-        let feedback_stream_clone = feedback_stream.clone();
-        let clients_clone = clients.clone();
-
-        tokio::spawn(async move {
-            loop {
-                match feedback_stream_clone.receive().await {
-                    Some(feedback) => {
-                        let led_msg = led_feedback_to_cled(&feedback);
-                        let mut to_remove = Vec::new();
-                        let clients_guard = clients_clone.read().await;
-                        for (idx, client_mutex) in clients_guard.iter().enumerate() {
-                            let mut client = client_mutex.lock().await;
-                            if let Err(e) = client.write_all(&led_msg).await {
-                                tracing::warn!("Failed to send feedback to client: {}", e);
-                                to_remove.push(idx);
-                            }
-                        }
-                        drop(clients_guard);
-                        if !to_remove.is_empty() {
-                            let mut clients_guard = clients_clone.write().await;
-                            for &idx in to_remove.iter().rev() {
-                                clients_guard.remove(idx);
-                            }
-                        }
-                    }
-                    None => {
-                        tracing::info!("Feedback stream closed, stopping feedback broadcast task");
-                        break;
-                    }
-                }
-            }
-        });
 
         loop {
             let (socket, addr) = listener.accept().await?;
@@ -282,31 +238,27 @@ impl BrokenithmTcpBackend {
 
             let clients_for_removal = clients.clone();
             let client_mutex_for_removal = client_mutex.clone();
-            let feedback_stream_clone = feedback_stream.clone();
-
+            let inbound_tx = self.inbound_tx.clone();
             tokio::spawn(async move {
                 Self::handle_connection(
                     client_mutex,
                     Some((clients_for_removal, client_mutex_for_removal)),
                     Some(addr),
-                    feedback_stream_clone,
+                    inbound_tx,
                 )
                 .await;
             });
         }
     }
 
-    async fn run_client(
-        &mut self,
-        connect_addr: SocketAddr,
-        feedback_stream: FeedbackEventStream,
-    ) -> eyre::Result<()> {
+    async fn run_client(&mut self, connect_addr: SocketAddr) -> eyre::Result<()> {
         loop {
             match TcpStream::connect(connect_addr).await {
                 Ok(socket) => {
                     tracing::info!("Connected to Brokenithm device at {}", connect_addr);
                     let socket = Arc::new(tokio::sync::Mutex::new(socket));
-                    Self::handle_connection(socket, None, None, feedback_stream.clone()).await;
+                    let inbound_tx = self.inbound_tx.clone();
+                    Self::handle_connection(socket, None, None, inbound_tx).await;
                 }
                 Err(e) => {
                     tracing::error!(
@@ -344,7 +296,8 @@ impl BrokenithmTcpBackend {
                         connect_addr
                     );
                     let socket = Arc::new(tokio::sync::Mutex::new(socket));
-                    Self::handle_connection(socket, None, None, self.feedback_stream.clone()).await;
+                    let inbound_tx = self.inbound_tx.clone();
+                    Self::handle_connection(socket, None, None, inbound_tx).await;
                 }
                 Err(e) => {
                     tracing::error!(
@@ -362,31 +315,8 @@ impl BrokenithmTcpBackend {
         socket: Arc<tokio::sync::Mutex<TcpStream>>,
         client_cleanup: Option<ClientCleanup>,
         addr: Option<SocketAddr>,
-        feedback_stream: FeedbackEventStream,
+        inbound_tx: tokio::sync::mpsc::UnboundedSender<IoInboundMessage>,
     ) {
-        let socket_for_feedback = socket.clone();
-
-        // Start feedback listening task
-        let feedback_stream_clone = feedback_stream.clone();
-        let feedback_task = tokio::spawn(async move {
-            loop {
-                match feedback_stream_clone.receive().await {
-                    Some(feedback) => {
-                        let led_msg = led_feedback_to_cled(&feedback);
-                        let mut socket_guard = socket_for_feedback.lock().await;
-                        if let Err(e) = socket_guard.write_all(&led_msg).await {
-                            tracing::warn!("Failed to send feedback: {e}");
-                            break;
-                        }
-                    }
-                    None => {
-                        tracing::info!("Feedback stream closed");
-                        break;
-                    }
-                }
-            }
-        });
-
         let mut buffer = Vec::new();
         let mut read_buf = [0u8; 256];
         let mut state_tracker = BrokenithmInputStateTracker::new();
@@ -400,7 +330,6 @@ impl BrokenithmTcpBackend {
                     } else {
                         tracing::info!("Connection closed by remote");
                     }
-                    feedback_task.abort();
 
                     // Remove this client from the shared list if it's a server connection
                     if let Some((clients_for_removal, client_mutex_for_removal)) = client_cleanup {
@@ -441,8 +370,18 @@ impl BrokenithmTcpBackend {
                                     test_button,
                                     service_button,
                                 ) {
-                                    // Don't send input events when using shared state polling
-                                    // let _ = input_stream.send(packet).await;
+                                    // Emit into unified IoEventServer
+                                    if let Some(packet) = state_tracker.diff_and_packet(
+                                        &air,
+                                        &slider,
+                                        test_button,
+                                        service_button,
+                                    ) {
+                                        let _ = inbound_tx.send(IoInboundMessage::Input {
+                                            client_id: "brokenithm".to_string(),
+                                            packet,
+                                        });
+                                    }
                                 }
                                 // Always update shared state regardless of event emission
                                 state_tracker.update_shared_state(test_button, service_button);
@@ -463,8 +402,17 @@ impl BrokenithmTcpBackend {
                                     test_button,
                                     service_button,
                                 ) {
-                                    // Don't send input events when using shared state polling
-                                    // let _ = input_stream.send(packet).await;
+                                    if let Some(packet) = state_tracker.diff_and_packet(
+                                        &air,
+                                        &slider,
+                                        test_button,
+                                        service_button,
+                                    ) {
+                                        let _ = inbound_tx.send(IoInboundMessage::Input {
+                                            client_id: "brokenithm".to_string(),
+                                            packet,
+                                        });
+                                    }
                                 }
                                 // Always update shared state after coin pulse
                                 state_tracker.update_shared_state(test_button, service_button);
@@ -488,7 +436,7 @@ impl BrokenithmTcpBackend {
                 }
                 Err(e) => {
                     tracing::error!("TCP read error: {}", e);
-                    feedback_task.abort();
+
                     break;
                 }
             }

--- a/src/input/io_server.rs
+++ b/src/input/io_server.rs
@@ -1,0 +1,967 @@
+//! Unified I/O server implementation
+//!
+//! # Overview
+//! A single asynchronous hub that normalizes all inbound messages coming from any
+//! transport/backend (WebSocket, Unix socket, plugin stdio, etc.) into a shared
+//! processing pipeline. It performs:
+//! * Per-client input buffering + atomic batching (via [`AtomicInputProcessor`])
+//! * Feedback (LED / other) rebroadcast + filtering
+//! * Control plane for dynamic stream/topic subscription & management
+//! * Outbound fan-out to output backends (uinput, chuniio, …) and interested clients
+//!
+//! # Terminology
+//! * **Client**: A connected producer/consumer (web page, plugin process, future TCP peer)
+//! * **Stream / Topic ID**: Arbitrary logical channel name a client can register for.
+//!   Output routing uses backend names as stream IDs (e.g. `"uinput"`, `"chuniio"`).
+//! * **Device ID**: The logical input device name contained inside each packet.
+//!
+//! # Inbound Message JSON Schemas (Text frames)
+//! Transports send UTF‑8 JSON. Binary frames are currently ignored.
+//!
+//! ## 1. Input Packet
+//! ```json
+//! {
+//!   "device_id": "keyboard1",
+//!   "timestamp": 1755488100050,
+//!   "events": [
+//!     { "Keyboard": { "KeyPress": { "key": "KEY_A" } } },
+//!     { "Keyboard": { "KeyRelease": { "key": "KEY_A" } } }
+//!   ]
+//! }
+//! ```
+//! Accepted fields map to [`InputEventPacket`]. Additional fields are ignored.
+//!
+//! ## 2. Feedback Packet
+//! ```json
+//! {
+//!   "device_id": "rgb-test",
+//!   "timestamp": 1755488100050,
+//!   "events": [
+//!     { "Led": { "Set": { "led_id": 0, "on": true, "brightness": 255, "rgb": [255,0,128] } } }
+//!   ]
+//! }
+//! ```
+//! Matches [`FeedbackEventPacket`]. Forwarded to all non write-only clients that either:
+//! * Have an empty `feedback_listener_device_ids` filter (subscribe to all), **or**
+//! * Explicitly include `device_id` in their filter list.
+//!
+//! ## 3. Control Messages
+//! Control messages allow a client to mutate subscriptions. Envelope:
+//! ```json
+//! { "type": "control", "cmd": <command object ...> }
+//! ```
+//! Supported commands (snake_case):
+//! * `register_streams` – Add (idempotently) one or more stream/topic IDs this client wants to receive.
+//!   ```json
+//!   { "type": "control", "cmd": "register_streams", "streams": ["uinput","foo"] }
+//!   ```
+//!   Response:
+//!   ```json
+//!   { "type": "control_ack", "registered_streams": ["uinput","foo"] }
+//!   ```
+//! * `list_streams` – Request the current union of all known registered stream IDs:
+//!   ```json
+//!   { "type": "control", "cmd": "list_streams" }
+//!   ```
+//!   Response:
+//!   ```json
+//!   { "type": "streams", "streams": ["uinput","chuniio","foo"] }
+//!   ```
+//!
+//! (Additional planned control commands: input / feedback filter updates & unregister.)
+//!
+//! # Outbound Messages to Clients
+//! Tagged union (serde `#[serde(tag = "type")]`) represented here conceptually:
+//! ```jsonc
+//! // Feedback echo/broadcast
+//! { "type": "Feedback", "data": { /* FeedbackEventPacket */ } }
+//! // Input packet routed to a subscribed stream/topic
+//! { "type": "Input", "data": { /* InputEventPacket */ } }
+//! // Error notification
+//! { "type": "Error", "data": { "code": "parse_error", "message": "...", "raw": "..." } }
+//! // Control responses (NOT part of IoClientMessage, emitted directly):
+//! { "type": "control_ack", ... }
+//! { "type": "streams", ... }
+//! ```
+//! NOTE: The `control_ack` & `streams` payloads are transport-level convenience responses,
+//! not serialized via `IoClientMessage` enum (they're sent directly in the websocket layer).
+//!
+//! # Stream / Topic Semantics
+//! * A client that registers stream `foo` will receive every outbound `Input` packet that the
+//!   routing service mirrors to stream `foo` (currently backend name == stream ID).
+//! * Multiple clients may register the same stream ID; each receives identical copies.
+//! * Registration is additive; duplicates are deduped client-side.
+//! * No explicit unregister yet (will be provided by a future control command).
+//! * Precedence: If a client has registered at least one stream/topic, device ID
+//!   based `input_listener_device_ids` filtering is ignored for input delivery (topic mode).
+//!   If no streams are registered, device filters apply. IMPORTANT: An empty
+//!   `input_listener_device_ids` list now means "subscribe to NONE" (opt‑in model).
+//!   Provide at least one device id to receive packets without using stream/topics.
+//!
+//! # Routing & Broadcasting Path
+//! 1. Client sends raw input → `IoInboundMessage::Input`.
+//! 2. Atomic processor batches; emits `IoOutboundMessage::Input`.
+//! 3. Backend routing service:
+//!    * Device filter transforms keys (remap / whitelist).
+//!    * Events partitioned by backend (e.g. `uinput`, `chuniio`).
+//!    * Packet delivered to output backend stream AND mirrored to any subscribed stream/topic.
+//! 4. Clients who registered that backend/topic receive `IoClientMessage::Input`.
+//! 5. Feedback packets (`IoInboundMessage::Feedback`) immediately rebroadcast & surfaced to all eligible clients.
+//!
+//! # Error Handling
+//! * Malformed JSON that does not match any known schema currently produces a warning only.
+//! * Future: explicit `Error` packet back to origin with code `parse_error`.
+//!
+//! # Versioning & Forward Compatibility
+//! This informal schema is considered unstable until a `protocol_version` control query
+//! is added. Add fields using `#[serde(skip_serializing_if = "Option::is_none")]` for
+//! forward compatibility.
+//!
+//! # Implementation Notes
+//! * The server internally tags device IDs temporarily with `@client_id` for atomic grouping
+//!   then strips the suffix before outbound emission.
+//! * Stream listing is derived dynamically (union over all client registrations).
+//! * `write_only` clients never receive feedback or input stream packets.
+//!
+//! # Adding a New Transport
+//! 1. Register client (choose an `id`).
+//! 2. Forward parsed input as `IoInboundMessage::Input`.
+//! 3. Forward feedback as `IoInboundMessage::Feedback`.
+//! 4. Parse & forward control JSON to `IoInboundMessage::Control` (wrapping client id).
+//! 5. Relay outbound `IoClientMessage` variants as text frames.
+//!
+//! Keep this documentation in sync when adding new control commands or message variants.
+use std::{collections::HashMap, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, RwLock, mpsc};
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    feedback::FeedbackEventPacket,
+    input::{InputBackend, InputEventPacket, atomic::AtomicInputProcessor},
+};
+
+/// A Client "node" in Backflow's I/O stream
+///
+/// This struct represents a single client connection in the I/O stream,
+/// allowing for the routing of I/O events
+///
+/// The client can be either a producer or a consumer of events,
+///
+/// and contributes to the overall pipeline
+///
+/// Backflow makes no distinctions between
+/// plugins and normal clients, as to any "client"
+/// can generate or consume events in any order they wish.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientNode {
+    pub id: String,
+    pub client_settings: ClientSettings,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ClientSettings {
+    /// Device IDs to subscribe feedback events from
+    /// By default, all feedback events will be subscribed to
+    pub feedback_listener_device_ids: Vec<String>,
+
+    /// Device IDs to subscribe input events from
+    /// By default, no events will be subscribed to
+    pub input_listener_device_ids: Vec<String>,
+
+    /// Registered stream IDs for the client, for filtering based on stream type instead
+    /// of device ID
+    ///
+    /// In other MQ systems, this is typically just called a "topic".
+    pub registered_stream_ids: Vec<String>,
+
+    /// Whether the client is write-only,
+    /// meaning they will not receive any feedback events
+    pub write_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ClientControlMessage {
+    /// Request that the server stop sending feedback events to this client
+    StopFeedback,
+
+    /// Request that the server stop sending input events to this client
+    StopInput,
+
+    /// Request that the server update the device ID filter for input events
+    UpdateInputDIDFilter(Vec<String>),
+
+    /// Request that the server update the device ID filter for feedback events
+    UpdateFeedbackDIDFilter(Vec<String>),
+
+    /// Request that the server update/register the stream and send events into that
+    /// stream/topic
+    ///
+    /// Streams will be created if they do not already exist.
+    UpdateStreamRegistration(Vec<String>),
+}
+
+/// Inbound message into the unified I/O processing pipeline
+#[derive(Debug, Clone)]
+pub enum IoInboundMessage {
+    /// Input events produced by a client
+    Input {
+        client_id: String,
+        packet: InputEventPacket,
+    },
+    /// Feedback events produced by a client (to be re-broadcast / routed)
+    Feedback {
+        client_id: String,
+        packet: FeedbackEventPacket,
+    },
+    /// Control messages sent from clients to the server
+    Control {
+        client_id: String,
+        msg: ClientControlMessage,
+    },
+}
+
+/// Outbound messages emitted by the IoEventServer after processing
+#[derive(Debug, Clone)]
+pub enum IoOutboundMessage {
+    /// Fully processed (atomic) input packet ready for routing / device filter
+    Input(InputEventPacket),
+    /// Feedback packet originating from any client (already broadcast internally)
+    Feedback(FeedbackEventPacket),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IoErrorPacket {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")] // explicit tagging for clearer JSON
+pub enum IoClientMessage {
+    Feedback(FeedbackEventPacket),
+    /// Stream/topic routed input packet
+    Input(InputEventPacket),
+    Error(IoErrorPacket),
+}
+
+#[derive(Clone)]
+struct ClientEntry {
+    settings: ClientSettings,
+    outbound_tx: mpsc::UnboundedSender<IoClientMessage>,
+}
+
+pub struct IoEventServer {
+    pub atomic_processor: Arc<AtomicInputProcessor>,
+    // Inbound (unprocessed) messages from transports / plugins
+    inbound_tx: mpsc::UnboundedSender<IoInboundMessage>,
+    inbound_rx: Arc<Mutex<mpsc::UnboundedReceiver<IoInboundMessage>>>,
+    // Unified outbound channel (processed input & feedback)
+    outbound_tx: mpsc::UnboundedSender<IoOutboundMessage>,
+    outbound_rx: Arc<Mutex<mpsc::UnboundedReceiver<IoOutboundMessage>>>,
+    clients: Arc<RwLock<HashMap<String, ClientEntry>>>,
+}
+
+impl IoEventServer {
+    /// Create a new unified I/O event server
+    pub fn new() -> Self {
+        let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+        Self {
+            atomic_processor: Arc::new(AtomicInputProcessor::new(Default::default())),
+            inbound_tx,
+            inbound_rx: Arc::new(Mutex::new(inbound_rx)),
+            outbound_tx,
+            outbound_rx: Arc::new(Mutex::new(outbound_rx)),
+            clients: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get a clone of the inbound sender so transport backends can submit messages
+    pub fn inbound_sender(&self) -> mpsc::UnboundedSender<IoInboundMessage> {
+        self.inbound_tx.clone()
+    }
+
+    /// Register a client with optional settings, returning a receiver for outbound feedback
+    pub async fn register_client(
+        &self,
+        client: ClientNode,
+    ) -> mpsc::UnboundedReceiver<IoClientMessage> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut guard = self.clients.write().await;
+        guard.insert(
+            client.id.clone(),
+            ClientEntry {
+                settings: client.client_settings,
+                outbound_tx: tx,
+            },
+        );
+        info!(client_id = %client.id, "Registered client to IoEventServer");
+        rx
+    }
+
+    /// Internal: process a single inbound input packet (after atomic processing)
+    async fn handle_input_packet(&self, client_id: &str, mut packet: InputEventPacket) {
+        debug!(client_id, device_id = %packet.device_id, events = packet.events.len(), "Received inbound input packet");
+
+        let original_device_id = packet.device_id.clone();
+        packet.device_id = format!("{original_device_id}@{client_id}");
+
+        match self.atomic_processor.process_packet(packet).await {
+            Ok(Some(mut atomic_packet)) => {
+                // Restore original device id (strip suffix)
+                if let Some(at_pos) = atomic_packet.device_id.rfind('@') {
+                    atomic_packet.device_id = atomic_packet.device_id[..at_pos].to_string();
+                } else {
+                    // fallback – should not happen
+                    atomic_packet.device_id = original_device_id;
+                }
+                if let Err(e) = self
+                    .outbound_tx
+                    .send(IoOutboundMessage::Input(atomic_packet))
+                {
+                    error!(client_id, error = %e, "Failed to enqueue processed input packet");
+                }
+            }
+            Ok(None) => {
+                debug!(client_id, "Packet buffered for atomic processing");
+            }
+            Err(e) => {
+                warn!(client_id, error = ?e, "Failed to process input packet");
+            }
+        }
+    }
+
+    /// Internal: forward feedback packet produced by a client into main feedback stream
+    fn handle_feedback_packet(&self, client_id: &str, packet: FeedbackEventPacket) {
+        debug!(client_id, device_id = %packet.device_id, events = packet.events.len(), "Received inbound feedback packet");
+        // Push to unified outbound queue
+        if let Err(e) = self
+            .outbound_tx
+            .send(IoOutboundMessage::Feedback(packet.clone()))
+        {
+            error!(client_id, error = %e, "Failed to enqueue feedback packet");
+        }
+        // Also dispatch to registered clients honoring filters
+        // spawn task to avoid blocking caller (which may be in the main loop)
+        let clients_arc = self.clients.clone();
+        tokio::spawn(async move {
+            let clients_snapshot = { clients_arc.read().await.clone() };
+            for (cid, entry) in clients_snapshot.iter() {
+                if entry.settings.write_only {
+                    continue;
+                }
+                if !entry.settings.feedback_listener_device_ids.is_empty()
+                    && !entry
+                        .settings
+                        .feedback_listener_device_ids
+                        .contains(&packet.device_id)
+                {
+                    continue;
+                }
+                let _ = entry
+                    .outbound_tx
+                    .send(IoClientMessage::Feedback(packet.clone()));
+                debug!(client_id = %cid, "Delivered feedback packet to client");
+            }
+        });
+    }
+    /// Handle a control message (mutates client subscription state)
+    async fn handle_control_message(&self, client_id: &str, msg: ClientControlMessage) {
+        use ClientControlMessage::*;
+        let mut clients = self.clients.write().await;
+        if let Some(entry) = clients.get_mut(client_id) {
+            match msg {
+                StopFeedback => {
+                    entry.settings.feedback_listener_device_ids.clear();
+                    entry.settings.write_only = true;
+                }
+                StopInput => {
+                    entry.settings.input_listener_device_ids.clear();
+                }
+                UpdateInputDIDFilter(list) => {
+                    entry.settings.input_listener_device_ids = list;
+                }
+                UpdateFeedbackDIDFilter(list) => {
+                    entry.settings.feedback_listener_device_ids = list;
+                    entry.settings.write_only = false; // ensure enabled
+                }
+                UpdateStreamRegistration(streams) => {
+                    for s in streams {
+                        if !entry.settings.registered_stream_ids.contains(&s) {
+                            entry.settings.registered_stream_ids.push(s);
+                        }
+                    }
+                }
+            }
+            debug!(client_id = %client_id, ?entry.settings.registered_stream_ids, "Applied control message");
+        } else {
+            warn!(client_id = %client_id, "Control message for unknown client");
+        }
+    }
+
+    /// Broadcast input packet to clients subscribed to a stream id
+    pub fn broadcast_stream_input(&self, stream_id: &str, packet: &InputEventPacket) {
+        let stream_id = stream_id.to_string();
+        let packet = packet.clone();
+        let clients = self.clients.clone();
+        tokio::spawn(async move {
+            let snapshot = { clients.read().await.clone() };
+            for (cid, entry) in snapshot.iter() {
+                if entry.settings.registered_stream_ids.contains(&stream_id) {
+                    let _ = entry
+                        .outbound_tx
+                        .send(IoClientMessage::Input(packet.clone()));
+                    debug!(client_id = %cid, stream=%stream_id, "Delivered stream input packet");
+                }
+            }
+        });
+    }
+    /// Broadcast input packet to clients that have subscribed by device id (input_listener_device_ids)
+    ///
+    /// Precedence rule: if a client has registered any stream IDs, we ONLY deliver packets that
+    /// match those streams via `broadcast_stream_input` (topic-based). If the client has not
+    /// registered streams (empty `registered_stream_ids`), then device ID filters apply:
+    ///  * Empty `input_listener_device_ids` => receive NO input (default lockdown)
+    ///  * Non-empty => receive only listed device IDs (whitelist)
+    pub fn broadcast_device_input(&self, packet: &InputEventPacket) {
+        let packet = packet.clone();
+        let clients = self.clients.clone();
+        tokio::spawn(async move {
+            let snapshot = { clients.read().await.clone() };
+            for (cid, entry) in snapshot.iter() {
+                // Skip clients that chose stream/topic registration path
+                if !entry.settings.registered_stream_ids.is_empty() {
+                    continue;
+                }
+                // Device filter evaluation (empty list -> no subscription)
+                if entry.settings.input_listener_device_ids.is_empty() {
+                    continue;
+                }
+                if !entry
+                    .settings
+                    .input_listener_device_ids
+                    .contains(&packet.device_id)
+                {
+                    continue;
+                }
+                let _ = entry
+                    .outbound_tx
+                    .send(IoClientMessage::Input(packet.clone()));
+                // debug!(client_id = %cid, device=%packet.device_id, "Delivered device input packet");
+            }
+        });
+    }
+    /// Send an error packet to a specific client (transport should call on parse/validation failure)
+    pub fn send_error(
+        &self,
+        client_id: &str,
+        code: impl Into<String>,
+        message: impl Into<String>,
+        raw: Option<String>,
+    ) {
+        let client_id_str = client_id.to_string();
+        let clients = self.clients.clone();
+        let code_s = code.into();
+        let msg_s = message.into();
+        tokio::spawn(async move {
+            let guard = clients.read().await;
+            if let Some(entry) = guard.get(&client_id_str) {
+                let _ = entry
+                    .outbound_tx
+                    .send(IoClientMessage::Error(IoErrorPacket {
+                        code: code_s,
+                        message: msg_s,
+                        raw,
+                    }));
+            } else {
+                warn!(client_id = %client_id_str, "Attempted to send error to unknown client");
+            }
+        });
+    }
+    /// Take exclusive ownership of the unified outbound receiver.
+    /// (Single-consumer model. Call once.)
+    pub async fn take_outbound_receiver(
+        &self,
+    ) -> Option<mpsc::UnboundedReceiver<IoOutboundMessage>> {
+        let mut guard = self.outbound_rx.lock().await;
+        // Replace with a fresh dummy receiver to avoid accidental reuse
+        let (dummy_tx, dummy_rx) = mpsc::unbounded_channel::<IoOutboundMessage>();
+        let original = std::mem::replace(&mut *guard, dummy_rx);
+        drop(dummy_tx); // dummy_tx dropped immediately
+        Some(original)
+    }
+
+    /// Returns current number of registered clients
+    pub async fn client_count(&self) -> usize {
+        self.clients.read().await.len()
+    }
+
+    /// List all currently registered stream/topic IDs across clients
+    pub async fn list_stream_ids(&self) -> Vec<String> {
+        let guard = self.clients.read().await;
+        let mut set = std::collections::BTreeSet::new();
+        for (_cid, entry) in guard.iter() {
+            for s in &entry.settings.registered_stream_ids {
+                set.insert(s.clone());
+            }
+        }
+        set.into_iter().collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl InputBackend for IoEventServer {
+    async fn run(&mut self) -> eyre::Result<()> {
+        info!("Starting IoEventServer unified processing loop");
+
+        // Start atomic processor flush timer -> enqueue batches
+        let mut flush_timer_rx = self.atomic_processor.start_flush_timer();
+        let outbound_tx = self.outbound_tx.clone();
+        tokio::spawn(async move {
+            while let Some(mut atomic_packet) = flush_timer_rx.recv().await {
+                if let Some(at_pos) = atomic_packet.device_id.rfind('@') {
+                    atomic_packet.device_id = atomic_packet.device_id[..at_pos].to_string();
+                }
+                if let Err(e) = outbound_tx.send(IoOutboundMessage::Input(atomic_packet)) {
+                    error!(error = %e, "Failed to enqueue atomic batch from flush timer");
+                }
+            }
+            debug!("Atomic processor flush task stopped (IoEventServer)");
+        });
+
+        // Main inbound processing loop
+        loop {
+            let next_msg = {
+                let mut rx = self.inbound_rx.lock().await;
+                rx.recv().await
+            };
+            match next_msg {
+                Some(IoInboundMessage::Input { client_id, packet }) => {
+                    self.handle_input_packet(&client_id, packet).await;
+                }
+                Some(IoInboundMessage::Feedback { client_id, packet }) => {
+                    self.handle_feedback_packet(&client_id, packet);
+                }
+                Some(IoInboundMessage::Control { client_id, msg }) => {
+                    self.handle_control_message(&client_id, msg).await;
+                }
+                None => {
+                    warn!("Inbound channel closed; IoEventServer stopping");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl IoEventServer {
+    /// Same as `run` but takes &self so it can be used behind Arc in transports.
+    pub async fn run_forever(&self) -> eyre::Result<()> {
+        info!("Starting IoEventServer unified processing loop (run_forever)");
+        // Start atomic processor flush timer -> enqueue batches
+        let mut flush_timer_rx = self.atomic_processor.start_flush_timer();
+        let outbound_tx = self.outbound_tx.clone();
+        tokio::spawn(async move {
+            while let Some(mut atomic_packet) = flush_timer_rx.recv().await {
+                if let Some(at_pos) = atomic_packet.device_id.rfind('@') {
+                    atomic_packet.device_id = atomic_packet.device_id[..at_pos].to_string();
+                }
+                if let Err(e) = outbound_tx.send(IoOutboundMessage::Input(atomic_packet)) {
+                    error!(error = %e, "Failed to enqueue atomic batch from flush timer");
+                }
+            }
+            debug!("Atomic processor flush task stopped (IoEventServer run_forever)");
+        });
+
+        loop {
+            let next_msg = {
+                let mut rx = self.inbound_rx.lock().await;
+                rx.recv().await
+            };
+            match next_msg {
+                Some(IoInboundMessage::Input { client_id, packet }) => {
+                    self.handle_input_packet(&client_id, packet).await;
+                }
+                Some(IoInboundMessage::Feedback { client_id, packet }) => {
+                    self.handle_feedback_packet(&client_id, packet);
+                }
+                Some(IoInboundMessage::Control { client_id, msg }) => {
+                    self.handle_control_message(&client_id, msg).await;
+                }
+                None => {
+                    warn!("Inbound channel closed; IoEventServer stopping (run_forever)");
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feedback::{FeedbackEvent, FeedbackEventPacket, LedEvent, LedPattern};
+    use crate::input::{InputEvent, InputEventPacket, KeyboardEvent};
+    use tokio::time::{Duration, timeout};
+
+    fn make_input_packet(device: &str, ts: u64) -> InputEventPacket {
+        InputEventPacket {
+            device_id: device.to_string(),
+            timestamp: ts,
+            events: vec![InputEvent::Keyboard(KeyboardEvent::KeyPress {
+                key: "KEY_A".into(),
+            })],
+        }
+    }
+
+    fn make_feedback_packet(device: &str, ts: u64) -> FeedbackEventPacket {
+        FeedbackEventPacket {
+            device_id: device.to_string(),
+            timestamp: ts,
+            events: vec![FeedbackEvent::Led(LedEvent::SetPattern {
+                led_id: 1,
+                pattern: LedPattern::Solid,
+            })],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_client_registration_and_error_delivery() {
+        let server = Arc::new(IoEventServer::new());
+        let run_server = server.clone();
+        tokio::spawn(async move {
+            let _ = run_server.run_forever().await;
+        });
+
+        let mut rx = server
+            .register_client(ClientNode {
+                id: "client1".into(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+        assert_eq!(server.client_count().await, 1);
+
+        // Send an error
+        server.send_error(
+            "client1",
+            "test_error",
+            "Something went wrong",
+            Some("RAW".into()),
+        );
+        let msg = timeout(Duration::from_millis(100), async { rx.recv().await })
+            .await
+            .expect("timed out waiting for error")
+            .expect("channel closed");
+        match msg {
+            IoClientMessage::Error(err) => {
+                assert_eq!(err.code, "test_error");
+                assert_eq!(err.message, "Something went wrong");
+                assert_eq!(err.raw.as_deref(), Some("RAW"));
+            }
+            _ => panic!("expected error message"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_input_packet_flow() {
+        let server = Arc::new(IoEventServer::new());
+        let run_server = server.clone();
+        tokio::spawn(async move {
+            let _ = run_server.run_forever().await;
+        });
+        // Register producer
+        let _producer_rx = server
+            .register_client(ClientNode {
+                id: "producer".into(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+
+        // Take outbound receiver (processed output)
+        let mut outbound_rx = server.take_outbound_receiver().await.unwrap();
+        let inbound = server.inbound_sender();
+        inbound
+            .send(IoInboundMessage::Input {
+                client_id: "producer".into(),
+                packet: make_input_packet("dev1", 10),
+            })
+            .unwrap();
+
+        let msg = timeout(Duration::from_millis(100), async {
+            outbound_rx.recv().await
+        })
+        .await
+        .expect("timeout")
+        .expect("channel closed");
+        match msg {
+            IoOutboundMessage::Input(pkt) => {
+                assert_eq!(pkt.device_id, "dev1"); // original restored
+                assert_eq!(pkt.events.len(), 1);
+                assert_eq!(pkt.timestamp, 10);
+            }
+            _ => panic!("expected input outbound packet"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_out_of_order_dropped() {
+        let server = Arc::new(IoEventServer::new());
+        let run_server = server.clone();
+        tokio::spawn(async move {
+            let _ = run_server.run_forever().await;
+        });
+        let _rx = server
+            .register_client(ClientNode {
+                id: "producer".into(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+        let mut outbound_rx = server.take_outbound_receiver().await.unwrap();
+        let inbound = server.inbound_sender();
+        // Send newer timestamp first
+        inbound
+            .send(IoInboundMessage::Input {
+                client_id: "producer".into(),
+                packet: make_input_packet("devX", 200),
+            })
+            .unwrap();
+        // Then older
+        inbound
+            .send(IoInboundMessage::Input {
+                client_id: "producer".into(),
+                packet: make_input_packet("devX", 100),
+            })
+            .unwrap();
+
+        // Expect only the first packet to emerge
+        let first = timeout(Duration::from_millis(100), async {
+            outbound_rx.recv().await
+        })
+        .await
+        .expect("timeout")
+        .expect("channel closed");
+        match first {
+            IoOutboundMessage::Input(pkt) => assert_eq!(pkt.timestamp, 200),
+            _ => panic!("expected input packet"),
+        }
+        // Ensure no second packet within window
+        let second = timeout(Duration::from_millis(80), async {
+            outbound_rx.recv().await
+        })
+        .await;
+        assert!(
+            second.is_err(),
+            "unexpected second packet emitted for out-of-order input"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_feedback_broadcast_and_filters() {
+        let server = Arc::new(IoEventServer::new());
+        let run_server = server.clone();
+        tokio::spawn(async move {
+            let _ = run_server.run_forever().await;
+        });
+        // Producer client
+        let _producer_rx = server
+            .register_client(ClientNode {
+                id: "producer".into(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+        // Default listener (should receive)
+        let mut default_rx = server
+            .register_client(ClientNode {
+                id: "listener_default".into(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+        // Write-only client (should NOT receive)
+        let mut write_only_rx = server
+            .register_client(ClientNode {
+                id: "listener_writeonly".into(),
+                client_settings: ClientSettings {
+                    write_only: true,
+                    ..Default::default()
+                },
+            })
+            .await;
+        // Filter mismatch client (subscribes only to other_device)
+        let mut mismatch_rx = server
+            .register_client(ClientNode {
+                id: "listener_mismatch".into(),
+                client_settings: ClientSettings {
+                    feedback_listener_device_ids: vec!["other_device".into()],
+                    ..Default::default()
+                },
+            })
+            .await;
+        // Filter match client (subscribes to leddev)
+        let mut match_rx = server
+            .register_client(ClientNode {
+                id: "listener_match".into(),
+                client_settings: ClientSettings {
+                    feedback_listener_device_ids: vec!["leddev".into()],
+                    ..Default::default()
+                },
+            })
+            .await;
+
+        let inbound = server.inbound_sender();
+        inbound
+            .send(IoInboundMessage::Feedback {
+                client_id: "producer".into(),
+                packet: make_feedback_packet("leddev", 1),
+            })
+            .unwrap();
+
+        // helper closure to try receive
+        async fn expect_feedback(rx: &mut mpsc::UnboundedReceiver<IoClientMessage>, should: bool) {
+            if should {
+                let msg = timeout(Duration::from_millis(120), async { rx.recv().await })
+                    .await
+                    .expect("timeout waiting for feedback")
+                    .expect("channel closed");
+                match msg {
+                    IoClientMessage::Feedback(pkt) => assert_eq!(pkt.device_id, "leddev"),
+                    other => panic!("expected feedback, got {:?}", other),
+                }
+            } else {
+                let res = timeout(Duration::from_millis(80), async { rx.recv().await }).await;
+                assert!(res.is_err(), "received unexpected feedback packet");
+            }
+        }
+
+        expect_feedback(&mut default_rx, true).await;
+        expect_feedback(&mut write_only_rx, false).await;
+        expect_feedback(&mut mismatch_rx, false).await;
+        expect_feedback(&mut match_rx, true).await;
+    }
+
+    #[tokio::test]
+    async fn test_device_input_broadcast_precedence() {
+        let server = Arc::new(IoEventServer::new());
+        let run_server = server.clone();
+        tokio::spawn(async move {
+            let _ = run_server.run_forever().await;
+        });
+
+        // Client A: device listener (no streams, listens to specific device devZ)
+        let mut dev_listener_rx = server
+            .register_client(ClientNode {
+                id: "dev_listener".into(),
+                client_settings: ClientSettings {
+                    input_listener_device_ids: vec!["devZ".into()],
+                    ..Default::default()
+                },
+            })
+            .await;
+        // Client B: empty list (should receive NONE now under new semantics)
+        let mut empty_rx = server
+            .register_client(ClientNode {
+                id: "empty".into(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+        // Client C: stream subscriber (registered_stream_ids non-empty, should NOT receive via device listener path)
+        let mut stream_client_rx = server
+            .register_client(ClientNode {
+                id: "stream_sub".into(),
+                client_settings: ClientSettings {
+                    registered_stream_ids: vec!["uinput".into()],
+                    ..Default::default()
+                },
+            })
+            .await;
+
+        // Simulate routing emission: directly call broadcast_device_input (mimic routing path)
+        let pkt = InputEventPacket {
+            device_id: "devZ".into(),
+            timestamp: 1,
+            events: vec![],
+        };
+        server.broadcast_device_input(&pkt);
+
+        // Expect A to receive, B (empty) NOT to, C not to (since precedence excludes device path)
+        let a = timeout(Duration::from_millis(120), async {
+            dev_listener_rx.recv().await
+        })
+        .await
+        .expect("timeout A")
+        .expect("A closed");
+        match a {
+            IoClientMessage::Input(p) => assert_eq!(p.device_id, "devZ"),
+            other => panic!("expected input for A got {:?}", other),
+        }
+        let b = timeout(Duration::from_millis(80), async { empty_rx.recv().await }).await;
+        assert!(
+            b.is_err(),
+            "empty filter client unexpectedly received input"
+        );
+        let c = timeout(Duration::from_millis(80), async {
+            stream_client_rx.recv().await
+        })
+        .await; // should timeout
+        assert!(
+            c.is_err(),
+            "stream subscriber unexpectedly received device-broadcast input"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_device_input_requires_opt_in() {
+        let server = Arc::new(IoEventServer::new());
+        let run_server = server.clone();
+        tokio::spawn(async move {
+            let _ = run_server.run_forever().await;
+        });
+
+        // Client with explicit opt-in
+        let mut listener_rx = server
+            .register_client(ClientNode {
+                id: "listener".into(),
+                client_settings: ClientSettings {
+                    input_listener_device_ids: vec!["devA".into()],
+                    ..Default::default()
+                },
+            })
+            .await;
+        // Client with empty list (default)
+        let mut default_rx = server
+            .register_client(ClientNode {
+                id: "default".into(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+
+        let pkt = InputEventPacket {
+            device_id: "devA".into(),
+            timestamp: 1,
+            events: vec![],
+        };
+        server.broadcast_device_input(&pkt);
+
+        // Opt-in client should receive
+        let got = timeout(Duration::from_millis(120), async {
+            listener_rx.recv().await
+        })
+        .await
+        .expect("timeout listener")
+        .expect("listener closed");
+        assert!(
+            matches!(got, IoClientMessage::Input(_)),
+            "expected Input message"
+        );
+
+        // Default client should not
+        let res = timeout(Duration::from_millis(80), async { default_rx.recv().await }).await;
+        assert!(res.is_err(), "default client received input without opt-in");
+    }
+}

--- a/src/input/io_server.rs
+++ b/src/input/io_server.rs
@@ -508,7 +508,9 @@ impl IoEventServer {
                 ClientControlMessage::GetConfig => {
                     // Non-mutating: send config snapshot
                     let cfg = (*self.app_config).clone();
-                    let _ = entry.outbound_tx.send(IoClientMessage::Config(Box::new(cfg)));
+                    let _ = entry
+                        .outbound_tx
+                        .send(IoClientMessage::Config(Box::new(cfg)));
                 }
             }
             // Emit centralized control_ack for mutating commands (excluding ListStreams)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub mod atomic;
 pub mod brokenithm;
 pub mod unix_socket;
+pub mod io_server;
 pub mod web;
 
 /// Represents a packet of input events, sent over a network or any other communication channel.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -5,8 +5,8 @@
 use serde::{Deserialize, Serialize};
 pub mod atomic;
 pub mod brokenithm;
-pub mod unix_socket;
 pub mod io_server;
+pub mod unix_socket;
 pub mod web;
 
 /// Represents a packet of input events, sent over a network or any other communication channel.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub mod atomic;
 pub mod brokenithm;
 pub mod io_server;
+pub mod stdio;
 pub mod unix_socket;
 pub mod web;
 

--- a/src/input/stdio.rs
+++ b/src/input/stdio.rs
@@ -1,0 +1,244 @@
+//! StdIO based transport.
+//!
+//! Mirrors the behaviour of the UNIX socket backend, but instead of a per-connection
+//! stream it uses the parent process' stdin (for inbound messages) and
+//! stdout (for outbound messages). Errors are also emitted as normal outbound
+//! `IoClientMessage::Error` variants over stdout so a supervising process can
+//! parse everything from a single stream. This allows simple composition with
+//! tools that can only speak over standard I/O (plugins, child processes, etc.).
+//!
+//! For now this backend is unconditional and not configurable; it's intended as
+//! a building block for future plugin execution models. One logical StdIO client
+//! is registered whose id is `stdio`.
+
+use crate::feedback::FeedbackEventPacket;
+use crate::input::io_server::{ClientNode, ClientSettings, IoEventServer, IoInboundMessage};
+use crate::input::{InputBackend, InputEventPacket};
+use eyre::Result;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tracing::{debug, error, info, warn};
+
+enum ReaderMode {
+    Inherit, // Use process stdin
+    Provided(BufReader<Box<dyn tokio::io::AsyncRead + Send + Unpin>>),
+}
+enum WriterMode {
+    Inherit, // Use process stdout
+    Provided(Box<dyn tokio::io::AsyncWrite + Send + Unpin>),
+}
+
+pub struct StdioBackend {
+    pub io_server: Arc<IoEventServer>,
+    client_id: String,
+    reader: ReaderMode,
+    writer: WriterMode,
+}
+
+impl StdioBackend {
+    /*
+    /// Standard constructor using the current process stdin/stdout with fixed id "stdio"
+    pub fn new(io_server: Arc<IoEventServer>) -> Self {
+        Self {
+            io_server,
+            client_id: "stdio".into(),
+            reader: ReaderMode::Inherit,
+            writer: WriterMode::Inherit,
+        }
+    }
+    */
+    /// Create a backend with custom reader & writer (e.g. plugin child process)
+    pub fn with_streams<R, W>(
+        client_id: impl Into<String>,
+        reader: R,
+        writer: W,
+        io_server: Arc<IoEventServer>,
+    ) -> Self
+    where
+        R: AsyncRead + Send + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        Self {
+            io_server,
+            client_id: client_id.into(),
+            reader: ReaderMode::Provided(BufReader::new(Box::new(reader))),
+            writer: WriterMode::Provided(Box::new(writer)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl InputBackend for StdioBackend {
+    async fn run(&mut self) -> Result<()> {
+        info!(client_id=%self.client_id, "Starting stdio transport backend");
+
+        let io_server = self.io_server.clone();
+        let client_id = self.client_id.clone();
+
+        // Register logical client
+        let mut outbound_rx = io_server
+            .register_client(ClientNode {
+                id: client_id.clone(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+        let inbound_tx = io_server.inbound_sender();
+
+        // Writer task (move ownership of provided writer out)
+        let client_id_reader = client_id.clone();
+        match std::mem::replace(&mut self.writer, WriterMode::Inherit) {
+            WriterMode::Provided(mut w) => {
+                let client_id_out = client_id.clone();
+                tokio::spawn(async move {
+                    while let Some(msg) = outbound_rx.recv().await {
+                        match serde_json::to_string(&msg) {
+                            Ok(json) => {
+                                if let Err(e) = w.write_all(json.as_bytes()).await {
+                                    warn!(%client_id_out, error=%e, "Failed writing json to stdio writer");
+                                    break;
+                                }
+                                if let Err(e) = w.write_all(b"\n").await {
+                                    warn!(%client_id_out, error=%e, "Failed writing newline to stdio writer");
+                                    break;
+                                }
+                                if let Err(e) = w.flush().await {
+                                    warn!(%client_id_out, error=%e, "Failed flushing stdio writer");
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                error!(%client_id_out, error=%e, "Failed serializing IoClientMessage")
+                            }
+                        }
+                    }
+                    debug!(%client_id_out, "StdIO provided writer outbound task ended");
+                });
+            }
+            WriterMode::Inherit => {
+                let client_id_out = client_id.clone();
+                tokio::spawn(async move {
+                    let mut stdout = tokio::io::stdout();
+                    while let Some(msg) = outbound_rx.recv().await {
+                        match serde_json::to_string(&msg) {
+                            Ok(json) => {
+                                if let Err(e) = stdout.write_all(json.as_bytes()).await {
+                                    warn!(%client_id_out, error=%e, "Failed writing stdout json");
+                                    break;
+                                }
+                                if let Err(e) = stdout.write_all(b"\n").await {
+                                    warn!(%client_id_out, error=%e, "Failed writing stdout newline");
+                                    break;
+                                }
+                                if let Err(e) = stdout.flush().await {
+                                    warn!(%client_id_out, error=%e, "Failed flushing stdout");
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                error!(%client_id_out, error=%e, "Failed serializing IoClientMessage for stdout")
+                            }
+                        }
+                    }
+                    debug!(%client_id_out, "StdIO outbound task ended");
+                });
+            }
+        }
+
+        // Reader loop using unified enum wrapper
+        enum ReaderLines {
+            Inherit(tokio::io::Lines<BufReader<tokio::io::Stdin>>),
+            Provided(tokio::io::Lines<BufReader<Box<dyn tokio::io::AsyncRead + Send + Unpin>>>),
+        }
+        impl ReaderLines {
+            async fn next_line(&mut self) -> std::io::Result<Option<String>> {
+                match self {
+                    ReaderLines::Inherit(lines) => lines.next_line().await,
+                    ReaderLines::Provided(lines) => lines.next_line().await,
+                }
+            }
+        }
+        let mut reader_lines = match std::mem::replace(&mut self.reader, ReaderMode::Inherit) {
+            ReaderMode::Inherit => {
+                let stdin = tokio::io::stdin();
+                ReaderLines::Inherit(BufReader::new(stdin).lines())
+            }
+            ReaderMode::Provided(buf) => ReaderLines::Provided(buf.lines()),
+        };
+        while let Ok(Some(line)) = reader_lines.next_line().await {
+            let line = line.trim_end().to_string();
+            if line.trim().is_empty() {
+                continue;
+            }
+            // Unified control parsing (same structure as unix + websocket)
+            if let Ok(env) = serde_json::from_str::<crate::input::io_server::ControlEnvelope>(&line)
+            {
+                if env.kind == "control" {
+                    use crate::input::io_server::ClientControlMessage;
+                    if let Ok(ctrl) = serde_json::from_value::<ClientControlMessage>(env.inner) {
+                        match ctrl {
+                            ClientControlMessage::ListStreams => {
+                                let streams = io_server.list_stream_ids().await;
+                                // We currently do not emit an ack over stdio (could print JSON line)
+                                let _ = streams; // silence unused for now
+                            }
+                            other => {
+                                let _ = inbound_tx.send(IoInboundMessage::Control {
+                                    client_id: client_id_reader.clone(),
+                                    msg: other,
+                                });
+                            }
+                        }
+                        continue;
+                    } else {
+                        io_server.send_app_error(
+                            &client_id_reader,
+                            crate::error::AppError::Parse("Failed to parse control command".into()),
+                        );
+                        continue;
+                    }
+                }
+            }
+            if let Ok(packet) = serde_json::from_str::<InputEventPacket>(&line) {
+                debug!(%client_id_reader, device=%packet.device_id, events=%packet.events.len(), "(stdio) inbound input");
+                if let Err(e) = inbound_tx.send(IoInboundMessage::Input {
+                    client_id: client_id_reader.clone(),
+                    packet,
+                }) {
+                    error!(%client_id_reader, error=%e, "Failed to forward stdio input");
+                }
+            } else if let Ok(packet) = serde_json::from_str::<FeedbackEventPacket>(&line) {
+                debug!(%client_id_reader, device=%packet.device_id, events=%packet.events.len(), "(stdio) inbound feedback");
+                if let Err(e) = inbound_tx.send(IoInboundMessage::Feedback {
+                    client_id: client_id_reader.clone(),
+                    packet,
+                }) {
+                    error!(%client_id_reader, error=%e, "Failed to forward stdio feedback");
+                }
+            } else {
+                warn!(%client_id_reader, "Failed to parse stdio line (neither input nor feedback nor control)");
+                io_server.send_app_error(
+                    &client_id_reader,
+                    crate::error::AppError::Parse(
+                        "Message was not a valid InputEventPacket or FeedbackEventPacket".into(),
+                    ),
+                );
+            }
+        }
+        info!(%client_id_reader, "StdIO backend exiting (reader closed)");
+        Ok(())
+    }
+}
+
+// Provide a no-op Clone similar to other backends if needed later
+impl Clone for StdioBackend {
+    fn clone(&self) -> Self {
+        Self {
+            io_server: self.io_server.clone(),
+            client_id: self.client_id.clone(),
+            // Cloning reader/writer modes: Inherit is copyable, Provided cannot be cloned safely.
+            // For simplicity, clones fall back to inherit mode (suitable for typical usage where clone isn't needed heavily).
+            reader: ReaderMode::Inherit,
+            writer: WriterMode::Inherit,
+        }
+    }
+}

--- a/src/input/unix_socket/mod.rs
+++ b/src/input/unix_socket/mod.rs
@@ -1,37 +1,25 @@
-use crate::feedback::{FeedbackEventPacket, FeedbackEventStream};
-use crate::input::atomic::AtomicInputProcessor;
-use crate::input::{InputBackend, InputEventPacket, InputEventStream};
+use crate::feedback::FeedbackEventPacket;
+use crate::input::io_server::{
+    ClientNode, ClientSettings, IoClientMessage, IoEventServer, IoInboundMessage,
+};
+use crate::input::{InputBackend, InputEventPacket};
 use eyre::{Context, Result};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
 pub struct UnixSocketServer {
     pub socket_path: PathBuf,
-    pub event_stream: InputEventStream,
-    pub feedback_stream: FeedbackEventStream,
-    pub connected_clients:
-        Arc<RwLock<Vec<tokio::sync::mpsc::UnboundedSender<FeedbackEventPacket>>>>,
-    pub atomic_processor: Arc<AtomicInputProcessor>,
+    pub io_server: Arc<IoEventServer>,
 }
 
 impl UnixSocketServer {
-    pub fn new(
-        socket_path: PathBuf,
-        event_stream: InputEventStream,
-        feedback_stream: FeedbackEventStream,
-    ) -> Self {
-        let atomic_processor = Arc::new(AtomicInputProcessor::new(Default::default()));
-
+    pub fn new(socket_path: PathBuf, io_server: Arc<IoEventServer>) -> Self {
         Self {
             socket_path,
-            event_stream,
-            feedback_stream,
-            connected_clients: Arc::new(RwLock::new(Vec::new())),
-            atomic_processor,
+            io_server,
         }
     }
 
@@ -40,96 +28,114 @@ impl UnixSocketServer {
         let (reader, writer) = stream.into_split();
         let mut lines = BufReader::new(reader).lines();
         let mut writer = BufWriter::new(writer);
-        let (feedback_tx, mut feedback_rx) =
-            tokio::sync::mpsc::unbounded_channel::<FeedbackEventPacket>();
+        info!("UNIX socket client connected");
 
-        // Add this client to the feedback broadcast list
-        {
-            let mut clients = self.connected_clients.write().await;
-            clients.push(feedback_tx);
-            info!(
-                "UNIX socket client added to feedback broadcast list. Total clients: {}",
-                clients.len()
-            );
-        }
-
-        let input_stream = self.event_stream.clone();
-        let feedback_stream_for_client = self.feedback_stream.clone();
-        let connected_clients = self.connected_clients.clone();
-        let atomic_processor = self.atomic_processor.clone();
+        let io_server = self.io_server.clone();
+        // Register a client node (one per socket connection)
+        let client_id = peer_addr.clone();
+        let feedback_rx_for_client = io_server
+            .register_client(ClientNode {
+                id: client_id.clone(),
+                client_settings: ClientSettings::default(),
+            })
+            .await;
+        let mut outbound_rx = feedback_rx_for_client; // IoClientMessage receiver
+        let _phantom_use: Option<IoClientMessage> = None; // keep type imported (avoid unused warning)
+        let inbound_tx = io_server.inbound_sender();
 
         // Task to handle incoming messages (input/feedback from client)
         let input_task = tokio::spawn(async move {
             while let Ok(Some(line)) = lines.next_line().await {
-                // Try to parse as InputEventPacket first
-                if let Ok(mut packet) = serde_json::from_str::<InputEventPacket>(&line) {
+                // Attempt control message parsing first (support camelCase and snake_case command names)
+                #[derive(serde::Deserialize)]
+                struct ControlProbe {
+                    #[serde(rename = "type")]
+                    kind: Option<String>,
+                    cmd: Option<String>,
+                }
+                if let Ok(probe) = serde_json::from_str::<ControlProbe>(&line) {
+                    if matches!(probe.kind.as_deref(), Some("control")) {
+                        use crate::input::io_server::ClientControlMessage;
+                        // Accept both `devices` and `device_ids` arrays
+                        #[derive(serde::Deserialize)]
+                        struct InputDidFilterPayload {
+                            #[serde(default, alias = "devices", alias = "device_ids")]
+                            pub devices: Vec<String>,
+                        }
+                        match probe.cmd.as_deref() {
+                            Some("UpdateInputDIDFilter") | Some("update_input_did_filter") => {
+                                if let Ok(payload) =
+                                    serde_json::from_str::<InputDidFilterPayload>(&line)
+                                {
+                                    let _ = inbound_tx.send(IoInboundMessage::Control {
+                                        client_id: client_id.clone(),
+                                        msg: ClientControlMessage::UpdateInputDIDFilter(
+                                            payload.devices.clone(),
+                                        ),
+                                    });
+                                    // Ack
+                                    // TODO: optional: write ack back on this control channel for UNIX socket clients
+                                } else {
+                                    io_server.send_error(
+                                        &client_id,
+                                        "invalid_control",
+                                        "Failed parsing UpdateInputDIDFilter payload",
+                                        Some(line.clone()),
+                                    );
+                                }
+                                continue;
+                            }
+                            _ => { /* unknown control cmd; fall through to other parsing */ }
+                        }
+                    }
+                }
+
+                if let Ok(packet) = serde_json::from_str::<InputEventPacket>(&line) {
                     debug!(
-                        "Received input packet from {}: device_id={}, events={}",
+                        "(unix) inbound input: client={}, device={}, events={}",
                         peer_addr,
                         packet.device_id,
                         packet.events.len()
                     );
-
-                    // Create a compound device ID that includes client address for atomicity tracking
-                    // This prevents out-of-order packet issues between different clients
-                    // while preserving the original device_id for the application
-                    let original_device_id = packet.device_id.clone();
-                    let atomicity_device_id = format!("{}@{}", packet.device_id, peer_addr);
-                    packet.device_id = atomicity_device_id;
-
-                    // Process through atomic processor for batching and ordering
-                    match atomic_processor.process_packet(packet).await {
-                        Ok(Some(mut atomic_packet)) => {
-                            // Restore the original device_id for the application
-                            atomic_packet.device_id = original_device_id;
-
-                            // Send the atomic batch to the input stream
-                            if let Err(e) = input_stream.send(atomic_packet).await {
-                                error!("Failed to send atomic input batch to stream: {}", e);
-                            } else {
-                                debug!(
-                                    "Successfully sent atomic input batch from {} to main input stream",
-                                    peer_addr
-                                );
-                            }
-                        }
-                        Ok(None) => {
-                            // Packet was buffered, will be sent later as part of an atomic batch
-                            debug!(
-                                "Input packet from {} buffered for atomic batching",
-                                peer_addr
-                            );
-                        }
-                        Err(e) => {
-                            warn!("Failed to process input packet from {}: {}", peer_addr, e);
-                        }
+                    if let Err(e) = inbound_tx.send(IoInboundMessage::Input {
+                        client_id: client_id.clone(),
+                        packet,
+                    }) {
+                        error!("Failed to forward input to IoEventServer: {}", e);
                     }
-                } else if let Ok(feedback_packet) =
-                    serde_json::from_str::<FeedbackEventPacket>(&line)
-                {
-                    info!(
-                        "Received feedback packet from {} for broadcast: device_id={}, events={}",
+                } else if let Ok(packet) = serde_json::from_str::<FeedbackEventPacket>(&line) {
+                    debug!(
+                        "(unix) inbound feedback: client={}, device={}, events={}",
                         peer_addr,
-                        feedback_packet.device_id,
-                        feedback_packet.events.len()
+                        packet.device_id,
+                        packet.events.len()
                     );
-                    if let Err(e) = feedback_stream_for_client.send(feedback_packet) {
-                        error!("Failed to send client feedback to main stream: {}", e);
+                    if let Err(e) = inbound_tx.send(IoInboundMessage::Feedback {
+                        client_id: client_id.clone(),
+                        packet,
+                    }) {
+                        error!("Failed to forward feedback to IoEventServer: {}", e);
                     }
                 } else {
-                    warn!("Failed to parse message from unix socket as input or feedback packet");
+                    warn!("Failed to parse message from unix socket (neither input nor feedback)");
+                    io_server.send_error(
+                        &client_id,
+                        "invalid_message",
+                        "Message was not a valid InputEventPacket or FeedbackEventPacket",
+                        Some(line.clone()),
+                    );
                 }
             }
             debug!("UNIX socket client input task finished");
         });
 
-        // Task to handle outgoing feedback events to client
+        // Task to handle outbound (feedback + errors) events to client
         let output_task = tokio::spawn(async move {
-            while let Some(feedback_packet) = feedback_rx.recv().await {
-                match serde_json::to_string(&feedback_packet) {
+            while let Some(msg) = outbound_rx.recv().await {
+                match serde_json::to_string(&msg) {
                     Ok(json) => {
                         if let Err(e) = writer.write_all(json.as_bytes()).await {
-                            warn!("Failed to send feedback to unix socket client: {}", e);
+                            warn!("Failed to send message to unix socket client: {}", e);
                             break;
                         }
                         if let Err(e) = writer.write_all(b"\n").await {
@@ -143,7 +149,7 @@ impl UnixSocketServer {
                     }
                     Err(e) => {
                         error!(
-                            "Failed to serialize feedback packet for unix socket client: {}",
+                            "Failed to serialize outbound message for unix socket client: {}",
                             e
                         );
                     }
@@ -154,16 +160,7 @@ impl UnixSocketServer {
 
         // Wait for either task to complete
         let _ = tokio::join!(input_task, output_task);
-
-        // Remove client from broadcast list
-        {
-            let mut clients = connected_clients.write().await;
-            clients.retain(|tx| !tx.is_closed());
-            info!(
-                "UNIX socket client removed from feedback broadcast list. Remaining: {}",
-                clients.len()
-            );
-        }
+        info!("UNIX socket client disconnected");
     }
 }
 
@@ -180,40 +177,7 @@ impl InputBackend for UnixSocketServer {
             self.socket_path.display()
         );
 
-        // Start the atomic processor flush timer
-        let mut flush_timer_rx = self.atomic_processor.start_flush_timer();
-        let input_stream_for_flush = self.event_stream.clone();
-
-        let _flush_task = tokio::spawn(async move {
-            while let Some(mut atomic_packet) = flush_timer_rx.recv().await {
-                // Restore original device_id from compound atomicity device_id
-                if let Some(at_pos) = atomic_packet.device_id.rfind('@') {
-                    atomic_packet.device_id = atomic_packet.device_id[..at_pos].to_string();
-                }
-
-                if let Err(e) = input_stream_for_flush.send(atomic_packet).await {
-                    error!("Failed to send atomic batch from flush timer: {}", e);
-                }
-            }
-            debug!("Atomic processor flush task stopped");
-        });
-
-        // Feedback broadcast task
-        let clients = self.connected_clients.clone();
-        let feedback_stream = self.feedback_stream.clone();
-        tokio::spawn(async move {
-            while let Some(feedback_packet) = feedback_stream.receive().await {
-                let clients_to_send = {
-                    let clients_guard = clients.read().await;
-                    clients_guard.clone()
-                };
-                for tx in &clients_to_send {
-                    if !tx.is_closed() {
-                        let _ = tx.send(feedback_packet.clone());
-                    }
-                }
-            }
-        });
+        // NOTE: atomic batching & feedback broadcast now handled by IoEventServer
 
         loop {
             match listener.accept().await {
@@ -235,10 +199,7 @@ impl Clone for UnixSocketServer {
     fn clone(&self) -> Self {
         Self {
             socket_path: self.socket_path.clone(),
-            event_stream: self.event_stream.clone(),
-            feedback_stream: self.feedback_stream.clone(),
-            connected_clients: self.connected_clients.clone(),
-            atomic_processor: self.atomic_processor.clone(),
+            io_server: self.io_server.clone(),
         }
     }
 }

--- a/src/input/web/server.rs
+++ b/src/input/web/server.rs
@@ -623,7 +623,8 @@ async fn handle_websocket_message(
             debug!("Received message from {}: {}", addr, text);
 
             // Unified control handling with ClientControlMessage
-            if let Ok(env) = serde_json::from_str::<crate::input::io_server::ControlEnvelope>(&text) {
+            if let Ok(env) = serde_json::from_str::<crate::input::io_server::ControlEnvelope>(&text)
+            {
                 if env.kind == "control" {
                     use crate::input::io_server::ClientControlMessage;
                     if let Ok(ctrl) = serde_json::from_value::<ClientControlMessage>(env.inner) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 mod backend;
 mod config;
 mod device_filter;
+mod error;
 mod feedback;
 mod input;
 mod output;
 mod protos;
-mod error;
 use eyre::Result;
 use tracing_subscriber::{Layer, layer::SubscriberExt};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod feedback;
 mod input;
 mod output;
 mod protos;
+mod error;
 use eyre::Result;
 use tracing_subscriber::{Layer, layer::SubscriberExt};
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -54,7 +54,6 @@ pub fn rgb_to_brg(rgb: &[u8; 3]) -> [u8; 3] {
 
 #[cfg(test)]
 mod tests {
-    use crate::feedback::FeedbackEventStream;
     use crate::feedback::generators::chuni_jvs::ChuniLedDataPacket;
     use crate::input::{InputEvent, InputEventPacket, InputEventStream, KeyboardEvent};
     use std::collections::HashMap;
@@ -70,8 +69,7 @@ mod tests {
     async fn test_chuniio_keyrelease_events_with_multiple_backends() {
         // Create streams
         let input_stream = InputEventStream::new();
-        let feedback_stream = FeedbackEventStream::new();
-        let (led_packet_tx, _led_packet_rx) = mpsc::unbounded_channel::<ChuniLedDataPacket>(); // Create a shared counter to track processed events
+    let (led_packet_tx, _led_packet_rx) = mpsc::unbounded_channel::<ChuniLedDataPacket>();
         let processed_events = Arc::new(Mutex::new(HashMap::<String, u32>::new()));
 
         // Create receivers before starting the backends to ensure they exist when we send events

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -69,7 +69,7 @@ mod tests {
     async fn test_chuniio_keyrelease_events_with_multiple_backends() {
         // Create streams
         let input_stream = InputEventStream::new();
-    let (led_packet_tx, _led_packet_rx) = mpsc::unbounded_channel::<ChuniLedDataPacket>();
+        let (led_packet_tx, _led_packet_rx) = mpsc::unbounded_channel::<ChuniLedDataPacket>();
         let processed_events = Arc::new(Mutex::new(HashMap::<String, u32>::new()));
 
         // Create receivers before starting the backends to ensure they exist when we send events


### PR DESCRIPTION
This PR adds a new "**plugins**" feature.

Plugins are regular executables that implement the Backflow IPC protocol. They can be run in two interchangeable ways:

- **Managed mode**: Backflow spawns the plugin as a child process, and communicates with it directly over stdio.
- **External mode**: The same plugin can be run independently (e.g. under systemd or a custom script), with its stdout/stderr piped into Backflow’s existing Unix Domain Socket (UDS) endpoint using tools like `socat`.

Both modes use the exact same API format (JSON + linefeed). The only difference is how the process is launched and where the I/O is routed. This ensures plugins are portable, composable, and not tied to Backflow’s internal process management.

Currently, you can use these plugins directly with the *External* deployment method aforementioned, so older versions without this PR merged is completely backwards-compatible with this new plugin system, provided you pipe their output or have it connect to UDS somehow, of course.

This approach is inspired by UCI chess engines; simple executables that speak a line-based protocol over stdio. The Backflow API protocol will be kept in sync with the UDS endpoint, so developers can choose whichever orchestration style best fits their deployment.

This PR also refactors the entire routing system, unifying the message routing system backend so that all transports (UDS, stdio, WebSockets) use the same codepath for processing I/O, allowing for easier maintainability. Only the transport server handles the transport-specific semantics while the actual input processor gets handled by the internal unified routing system

However, this PR also adds a new message type; Control messages.

Control messages are well, control messages specific to a client session, that allows clients/plugins to configure what kind of stream they want to subscribe to, or filter data by device ID and such. This allows other non-WebSocket plugins to filter messages beyond just declaring that the client does not accept any feedback events (write-only mode)

To put it simply-ish: Any client can be its own sink/frontend, as in ***you are no longer limited to SEGA IO4 and uinput***. To extend functionality and create a new driver sink, you can create a "client" (a simple executable, can be anything from shell scripts to full compiled programs), make it send a control message on startup to register a stream topic or filter by device name, and then subscribe to those messages, and process them to wherever you wanted it to go. Be it GPIO, SPI, or even just custom web requests or your arbitrary code, as long as you write a client that reads JSON.